### PR TITLE
Feature/simplified IK interface

### DIFF
--- a/lib/include/robot_interface/baxter_trac_ik.h
+++ b/lib/include/robot_interface/baxter_trac_ik.h
@@ -2,8 +2,7 @@
 #include <ros/ros.h>
 #include <kdl/chainiksolverpos_nr_jl.hpp>
 #include <sensor_msgs/JointState.h>
-
-#include "robot_utils/utils.h"
+#include <baxter_core_msgs/SolvePositionIK.h>
 
 class baxterTracIK
 {
@@ -26,7 +25,7 @@ public:
 
     KDL::JntArray JointState2JntArray(const sensor_msgs::JointState &js);
 
-    bool perform_ik(IK_call &ik);
+    bool perform_ik(baxter_core_msgs::SolvePositionIK &ik_srv);
 
     bool getKDLLimits(KDL::JntArray &ll, KDL::JntArray &ul);
     bool setKDLLimits(KDL::JntArray  ll, KDL::JntArray  ul);

--- a/lib/include/robot_utils/utils.h
+++ b/lib/include/robot_utils/utils.h
@@ -128,25 +128,4 @@ public:
     operator ros::Time ();
 };
 
-/**
- * Struct that handles the Inverse kinematics call to the baxter IK service
- */
-struct IK_call
-{
-    struct IK_req
-    {
-        geometry_msgs::PoseStamped pose_stamp;
-        sensor_msgs::JointState   seed_angles;
-    };
-
-    struct IK_res
-    {
-        sensor_msgs::JointState joints;
-        bool                   isValid;
-    };
-
-    IK_req req;
-    IK_res res;
-};
-
 #endif

--- a/lib/src/robot_interface/robot_interface.cpp
+++ b/lib/src/robot_interface/robot_interface.cpp
@@ -303,30 +303,22 @@ bool RobotInterface::computeIK(double px, double py, double pz,
 
     while (!got_solution)
     {
-        IK_call ik;
         SolvePositionIK ik_srv;
 
-        if (_use_trac_ik)
-        {
-            pose_stamp.header.stamp=ros::Time::now();
-            ik.req.pose_stamp  = pose_stamp;
+        pose_stamp.header.stamp=ros::Time::now();
 
-            pthread_mutex_lock(&_mutex_jnts);
-            ik.req.seed_angles = _curr_jnts;
-            pthread_mutex_unlock(&_mutex_jnts);
-        }
-        else
-        {
-            //ik_srv.request.seed_mode=2;       // i.e. SEED_CURRENT
-            ik_srv.request.seed_mode=0;         // i.e. SEED_AUTO
-            pose_stamp.header.stamp=ros::Time::now();
-            ik_srv.request.pose_stamp.push_back(pose_stamp);
-        }
+        //ik_srv.request.seed_mode=2;       // i.e. SEED_CURRENT
+        ik_srv.request.seed_mode=0;         // i.e. SEED_AUTO
+
+        ik_srv.request.pose_stamp.push_back(pose_stamp);
+        pthread_mutex_lock(&_mutex_jnts);
+        ik_srv.request.seed_angles.push_back(_curr_jnts);
+        pthread_mutex_unlock(&_mutex_jnts);
 
         int cnt = 0;
         ros::Time tn = ros::Time::now();
 
-        bool result = _use_trac_ik?ik_solver.perform_ik(ik):_ik_client.call(ik_srv);
+        bool result = _use_trac_ik?ik_solver.perform_ik(ik_srv):_ik_client.call(ik_srv);
 
         if(result)
         {
@@ -336,12 +328,11 @@ bool RobotInterface::computeIK(double px, double py, double pz,
                 ROS_WARN_ONCE("\t\t\tTime elapsed in computing IK: %g cnt %i",te,cnt);
             }
             cnt++;
-            got_solution = _use_trac_ik?ik.res.isValid:ik_srv.response.isValid[0];
 
-            if (got_solution)
+            if (ik_srv.response.isValid[0])
             {
                 ROS_DEBUG("Got solution!");
-                joint_angles = _use_trac_ik?ik.res.joints.position:ik_srv.response.joints[0].position;
+                joint_angles = ik_srv.response.joints[0].position;
                 return true;
             }
             else


### PR DESCRIPTION
Simplified the Inverse Kinematics interface. Now both `trac_ik` and the default inverse kinematics solver use the same interface. Tested on the robot.