### PR TITLE
fix integer type of object id for service call

### DIFF
--- a/srv/DoAction.srv
+++ b/srv/DoAction.srv
@@ -1,6 +1,6 @@
 string action
 # id of object (max 255)
-int8 object
+int16 object
 ---
 bool   success
 string response


### PR DESCRIPTION
allows higher object ids