### PR TITLE
Fixes #21

### DIFF
--- a/lib/include/robot_interface/arm_ctrl.h
+++ b/lib/include/robot_interface/arm_ctrl.h
@@ -22,31 +22,37 @@ private:
     // long actions that need multiple internal states, or
     // to store the error state of the controller in case of
     // unsuccessful actions
-    std::string   sub_state;
+    std::string       sub_state;
 
     // High level action the controller is engaged in
-    std::string       action;
+    std::string          action;
 
     // Previous high level action (for complex actions)
-    std::string  prev_action;
+    std::string     prev_action;
 
-    // Object the controller is acting upon (if the action
-    // is done with respect to an object)
-    int          object_id;
+    // Vector of object ids the client is requesting the controller to act upon.
+    // Among them, the controller will select those available in the DB, those
+    // visible in the field of view and if there still is multiple choice,
+    // it will randomly pick one of them
+    std::vector<int> object_ids;
+
+    // Selected Object ID the controller is acting upon (if the action is done with
+    // respect to an object), among the list of requested objects
+    int           sel_object_id;
 
     // Flag to know if the robot will try to recover from an error
     // or will wait the external planner to take care of that
-    bool internal_recovery;
+    bool      internal_recovery;
 
     // Service to request actions to
-    ros::ServiceServer service;
+    ros::ServiceServer  service;
 
     // Internal service used for multi-arm actions
     ros::ServiceServer service_other_limb;
 
     // Publisher to publish the high-level state of the controller
     // (to be shown in the Baxter display)
-    ros::Publisher     state_pub;
+    ros::Publisher    state_pub;
 
     // Home configuration. Setting it in any of the children
     // of this class is mandatory (through the virtual method
@@ -355,17 +361,19 @@ public:
 
     /* Self-explaining "setters" */
     virtual void setSubState(std::string _state);
-    virtual void setObjectID(int _obj) { object_id =    _obj; };
+    virtual void setObjectID(int _obj)                { sel_object_id =  _obj; };
+    virtual void setObjectIDs(std::vector<int> _objs) { object_ids    = _objs; };
     void setAction(std::string _action);
     void setPrevAction(std::string _prev_action);
     void setState(int _state);
 
     /* Self-explaining "getters" */
-    std::string   getSubState() { return         sub_state; };
-    std::string     getAction() { return            action; };
-    std::string getPrevAction() { return       prev_action; };
-    int           getObjectID() { return         object_id; };
-    bool  getInternalRecovery() { return internal_recovery; };
+    std::string       getSubState() { return         sub_state; };
+    std::string         getAction() { return            action; };
+    std::string     getPrevAction() { return       prev_action; };
+    int               getObjectID() { return     sel_object_id; };
+    std::vector<int> getObjectIDs() { return        object_ids; };
+    bool      getInternalRecovery() { return internal_recovery; };
 };
 
 #endif

--- a/lib/include/robot_perception/aruco_client.h
+++ b/lib/include/robot_perception/aruco_client.h
@@ -22,24 +22,40 @@ private:
     std::vector<int> available_markers;
 
     // Bool to check if ARuco is fine or not
-    bool     aruco_ok;
+    bool              aruco_ok;
 
-    // Bool to check if the marker was found or not
-    bool marker_found;
+    // Bool to check if there are any markers detected
+    bool         markers_found;
+
+    // Bool to check if the selected marker was found or not
+    bool          marker_found;
 
     // ID of the marker to detect
-    int     marker_id;
+    int              marker_id;
 
     // Marker position and orientation
-    geometry_msgs::Point        _curr_marker_pos;
-    geometry_msgs::Quaternion   _curr_marker_ori;
+    geometry_msgs::Point        curr_marker_pos;
+    geometry_msgs::Quaternion   curr_marker_ori;
 
 protected:
 
     /**
-     * Clears the marker pose to reset its state internally
+     * Resets the ARuco state in order to wait for
+     * fresh, new data from the topic
      */
-    void clearMarkerPose();
+    void resetARuco();
+
+    /**
+     * Clears the marker found flag to reset its state internally
+     * and wait for fresh, new data
+     */
+    void clearMarkerFound();
+
+    /**
+     * Clears the markers_found flag to reset its state internally
+     * and wait for fresh, new data
+     */
+    void clearMarkersFound();
 
     /**
      * Callback function for the ARuco topic
@@ -48,28 +64,43 @@ protected:
     void ARucoCb(const aruco_msgs::MarkerArray& msg);
 
     /**
-     * Waits to get feedback from aruco
+     * Waits to get feedback from ARuco
      * @return true/false if success/failure
      */
     bool waitForARucoOK();
 
     /**
-     * Waits for useful data coming from ARuco
+     * Waits to see if there are any markers detected
+     * @return true/false if success/failure
+     */
+    bool waitForARucoMarkersFound();
+
+    /**
+     * Waits to see if the desired marker has been detected
+     * @return true/false if success/failure
+     */
+    bool waitForARucoMarkerFound();
+
+    /**
+     * Waits for useful data coming from ARuco. It performs all the wait* functions
+     * declared above (i.e. waitForARucoOK(), waitForARucoMarkersFound()
+     * and waitForARucoMarkerFound())
      * @return true/false if success/failure
      */
     bool waitForARucoData();
 
     /*
      * Check availability of the ARuco data
+     * @return true/false if feedback from ARuco is received
     */
-    bool is_aruco_ok() { return aruco_ok; };
+    bool isARucoOK() { return aruco_ok; };
 
     /* SETTERS */
-    void setMarkerID(int _id)            { marker_id =     _id; };
+    void setMarkerID(int _id)                { marker_id = _id; };
 
     /* GETTERS */
-    geometry_msgs::Point      getMarkerPos() { return _curr_marker_pos; };
-    geometry_msgs::Quaternion getMarkerOri() { return _curr_marker_ori; };
+    geometry_msgs::Point      getMarkerPos() { return curr_marker_pos; };
+    geometry_msgs::Quaternion getMarkerOri() { return curr_marker_ori; };
 
     std::string getArucoLimb() { return     _limb; };
     int         getMarkerID()  { return marker_id; };
@@ -82,7 +113,7 @@ protected:
 
     /**
      * Looks if a set of markers is present among those available.
-     * @return the subset of available markers among those avilable
+     * @return the subset of available markers among those available
      */
     std::vector<int> getAvailableMarkers(std::vector<int> _markers);
 

--- a/lib/include/robot_perception/aruco_client.h
+++ b/lib/include/robot_perception/aruco_client.h
@@ -37,8 +37,6 @@ private:
     geometry_msgs::Point        curr_marker_pos;
     geometry_msgs::Quaternion   curr_marker_ori;
 
-protected:
-
     /**
      * Resets the ARuco state in order to wait for
      * fresh, new data from the topic
@@ -56,6 +54,8 @@ protected:
      * and wait for fresh, new data
      */
     void clearMarkersFound();
+
+protected:
 
     /**
      * Callback function for the ARuco topic

--- a/lib/include/robot_perception/cartesian_estimator_client.h
+++ b/lib/include/robot_perception/cartesian_estimator_client.h
@@ -24,7 +24,10 @@ private:
     // Bool to check the CartesianEstimator is fine or not
     bool         cartest_ok;
 
-    // Bool to check if the object was found or not
+    // Bool to check if there are any objects detected
+    bool      objects_found;
+
+    // Bool to check if the selected object was found or not
     bool       object_found;
 
     // Name of the object to detect
@@ -37,9 +40,22 @@ private:
 protected:
 
     /**
-     * Clears the object pose to reset its state internally
+     * Resets the cartesian estimator state in order to wait for
+     * fresh, new data from the topic
      */
-    void clearObjectPose();
+    void resetCartEst();
+
+    /**
+     * Clears the object found flag to reset its state internally
+     * and wait for fresh, new data
+     */
+    void clearObjFound();
+
+    /**
+     * Clears the objects_found flag to reset its state internally
+     * and wait for fresh, new data
+     */
+    void clearObjsFound();
 
     /**
      * Callback function for the CartesianEstimator topic
@@ -54,25 +70,40 @@ protected:
     bool waitForCartEstOK();
 
     /**
-     * Waits for useful data coming from CartesianEstimator
+     * Waits to see if there are any objects detected
+     * @return true/false if success/failure
+     */
+    bool waitForCartEstObjsFound();
+
+    /**
+     * Waits to see if the desired object has been detected
+     * @return true/false if success/failure
+     */
+    bool waitForCartEstObjFound();
+
+    /**
+     * Waits for useful data coming from CartesianEstimator. It performs
+     * all the wait* functions declared above (i.e. waitForCartEstOK(),
+     * waitForCartEstObjsFound() and waitForCartEstObjFound())
      * @return true/false if success/failure
      */
     bool waitForCartEstData();
 
     /*
      * Check availability of the CartesianEstimator data
+     * @return true/false if feedback from the cartesian estimator is received
     */
-    bool is_cartesian_estimator_ok() { return cartest_ok; };
+    bool isCartEstOK() { return   cartest_ok; };
 
     /* SETTERS */
-    void setObjectName(std::string _name)    { object_name =     _name; };
+    void setObjectName(std::string _name)    { object_name = _name; };
 
     /* GETTERS */
     geometry_msgs::Point      getObjectPos() { return curr_object_pos; };
     geometry_msgs::Quaternion getObjectOri() { return curr_object_ori; };
 
-    std::string getCartesianEstimatorLimb() { return        limb; };
-    std::string getObjectName()             { return object_name; };
+    std::string getCartEstLimb() { return        limb; };
+    std::string getObjectName()  { return object_name; };
 
     /**
      * Returns a list of available markers
@@ -82,7 +113,7 @@ protected:
 
     /**
      * Looks if a set of markers is present among those available.
-     * @return the subset of available markers among those avilable
+     * @return the subset of available markers among those available
      */
     std::vector<std::string> getAvailableObjects(std::vector<std::string> _objects);
 

--- a/lib/include/robot_perception/cartesian_estimator_client.h
+++ b/lib/include/robot_perception/cartesian_estimator_client.h
@@ -37,8 +37,6 @@ private:
     geometry_msgs::Point        curr_object_pos;
     geometry_msgs::Quaternion   curr_object_ori;
 
-protected:
-
     /**
      * Resets the cartesian estimator state in order to wait for
      * fresh, new data from the topic
@@ -56,6 +54,8 @@ protected:
      * and wait for fresh, new data
      */
     void clearObjsFound();
+
+protected:
 
     /**
      * Callback function for the CartesianEstimator topic

--- a/lib/src/robot_interface/arm_ctrl.cpp
+++ b/lib/src/robot_interface/arm_ctrl.cpp
@@ -127,7 +127,7 @@ bool ArmCtrl::serviceCb(baxter_collaboration::DoAction::Request  &req,
 
     if (action != ACTION_HOME && action != ACTION_RELEASE && action != ACTION_HOLD)
     {
-        object_ids = areObjectsInDB(object_ids);
+        setObjectIDs(areObjectsInDB(object_ids));
 
         if      (object_ids.size() == 0)
         {
@@ -281,6 +281,8 @@ std::vector<int> ArmCtrl::areObjectsInDB(const std::vector<int> &_objs)
             res.push_back(_objs[i]);
         }
     }
+
+    ROS_DEBUG("[%s] Found %lu objects in DB.", getLimb().c_str(), res.size());
 
     return res;
 }

--- a/src/modular_furniture/tool_picker.cpp
+++ b/src/modular_furniture/tool_picker.cpp
@@ -184,8 +184,17 @@ int ToolPicker::chooseObjectID(std::vector<int> _objs)
 {
     int res = -1;
 
-    // if (!hoverAbovePool()) return res;
-    if (!waitForCartEstOK())        return res;
+    if (!waitForCartEstOK())
+    {
+        setSubState(NO_OBJ);
+        return false;
+    }
+
+    if (!waitForCartEstObjsFound())
+    {
+        setSubState(NO_OBJ);
+        return false;
+    }
 
     std::vector<string> objs_str;
     for (size_t i = 0; i < _objs.size(); ++i)
@@ -265,6 +274,18 @@ bool ToolPicker::cleanUpObject()
 {
     if (!goToPose(0.65, -0.25, 0.25, VERTICAL_ORI_R)) return false;
     ros::Duration(0.05).sleep();
+
+    if (getObjectIDs().size() >  1)
+    {
+        setObjectID(chooseObjectID(getObjectIDs()));
+    }
+
+    if (!waitForCartEstObjFound())
+    {
+        setSubState(NO_OBJ);
+        return false;
+    }
+
     if (!pickUpObject())            return false;
     if (!gripObject())              return false;
     if (!moveArm("up", 0.3))        return false;

--- a/src/modular_furniture/tool_picker.cpp
+++ b/src/modular_furniture/tool_picker.cpp
@@ -148,7 +148,7 @@ bool ToolPicker::computeOffsets(double &_x_offs, double &_y_offs)
         else if (CartesianEstimatorClient::getObjectName() == "screws_box"  ||
                  CartesianEstimatorClient::getObjectName() == "brackets_box")
         {
-            _x_offs = -0.025;
+            _x_offs =  0.020;
             _y_offs = -0.058;
         }
     }
@@ -182,6 +182,12 @@ bool ToolPicker::computeOrientation(geometry_msgs::Quaternion &_q)
 
 int ToolPicker::chooseObjectID(std::vector<int> _objs)
 {
+    if (getSubState() != CHECK_OBJ_IDS)
+    {
+        return ArmCtrl::chooseObjectID(_objs);
+    }
+
+    ROS_DEBUG("[%s] Choosing object IDs", getLimb().c_str());
     int res = -1;
 
     if (!waitForCartEstOK())
@@ -277,7 +283,10 @@ bool ToolPicker::cleanUpObject()
 
     if (getObjectIDs().size() >  1)
     {
+        setSubState(CHECK_OBJ_IDS);
         setObjectID(chooseObjectID(getObjectIDs()));
+        ROS_INFO("[%s] Chosen object with ID %i", getLimb().c_str(),
+                                                     getObjectID());
     }
 
     if (!waitForCartEstObjFound())
@@ -297,11 +306,11 @@ bool ToolPicker::cleanUpObject()
     }
     else if (CartesianEstimatorClient::getObjectName() == "brackets_box")
     {
-        if (!goToPose(0.00, -0.85, -0.20, POOL_ORI_R)) return false;
+        if (!goToPose(0.00, -0.85, -0.25, POOL_ORI_R)) return false;
     }
     else if (CartesianEstimatorClient::getObjectName() == "screws_box")
     {
-        if (!goToPose(-0.15, -0.85, -0.20, POOL_ORI_R)) return false;
+        if (!goToPose(-0.15, -0.85, -0.25, POOL_ORI_R)) return false;
     }
 
     ros::Duration(0.5).sleep();

--- a/src/modular_furniture/tool_picker.h
+++ b/src/modular_furniture/tool_picker.h
@@ -10,6 +10,8 @@
 
 #define ACTION_CLEANUP  "cleanup"
 
+#define  CHECK_OBJ_IDS  "check_obj_ids"
+
 class ToolPicker : public HoldCtrl, public CartesianEstimatorClient
 {
 private:


### PR DESCRIPTION
Now the arm controller has a memory of the list objects to choose from. Its derived classes can then specialize `chooseObjectID()` and called whenever they prefer. See https://github.com/ScazLab/baxter_collaboration/commit/3d0c55971d669b1c306007bd45791a179058c4b4 for an example.