### PR TITLE
unit tests for ROS Thread Obj

### DIFF
--- a/baxter_collaboration_lib/CMakeLists.txt
+++ b/baxter_collaboration_lib/CMakeLists.txt
@@ -152,6 +152,10 @@ if(CATKIN_ENABLE_TESTING)
                                          test/test_gripper.cpp)
   target_link_libraries(test_gripper robot_interface ${catkin_LIBRARIES})
 
+  ## ROS thread obj tests
+  catkin_add_gtest(test_ros_thread_obj test/test_ros_thread_obj.cpp)
+  target_link_libraries(test_ros_thread_obj robot_utils)
+
 endif()
 
 ## Add folders to be run by python nosetests

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -14,16 +14,16 @@ class ROSThreadObjTest
 {
 
 private:
-    int var;                                    // variable to be modified by different threads
-    std::mutex mtx;                             // mutex for controlled thread access
+    int var;                                 // variable to be modified by different threads
+    std::mutex mtx;                          // mutex for controlled thread access
 
-    std::vector<ROSThreadObj>        threads;   // vector of ROSThreadObj
-    std::vector<void *(*)(void *)> functions;   // vector of thread entry functions
+    std::vector<ROSThreadObj>      threads;  // vector of ROSThreadObj
+    std::vector<void *(*)(void *)>   funcs;  // vector of thread entry functions
 
     /**
      * Does an arithmetic operation on the value of var thread-safely
      */
-    bool safe_arithmetic(const std::string& operation, int arg)
+    bool safeArithmetic(const std::string& operation, int arg)
     {
         std::lock_guard<std::mutex> lk(mtx);
 
@@ -37,34 +37,19 @@ private:
     }
 
     /**
-     * Prints the value of var
-     */
-    static void* print_var_wrapper(void* obj)
-    {
-        ((ROSThreadObjTest*) obj)->print_var();
-
-        return NULL;
-    }
-
-    void print_var()
-    {
-        cout << get_var() << endl;
-    }
-
-    /**
      * Adds 10 to the value of var in 10 milliseconds
      */
-    static void* ten_adder_wrapper(void* obj)
+    static void* tenAdderWrapper(void* obj)
     {
-        ((ROSThreadObjTest*) obj)->ten_adder();
+        ((ROSThreadObjTest*) obj)->tenAdder();
         return NULL;
     }
 
-    void ten_adder()
+    void tenAdder()
     {
         for (size_t i = 0; i < 10; ++i)
         {
-            safe_arithmetic("addition", 1);
+            safeArithmetic("addition", 1);
             sleep(0.01);
         }
     }
@@ -72,13 +57,13 @@ private:
     /**
      * Multiplies the value of var by 10 in 20 milliseconds
      */
-    static void* ten_multiplier_wrapper(void* obj)
+    static void* tenMultiplierWrapper(void* obj)
     {
-        ((ROSThreadObjTest*) obj)->ten_multiplier();
+        ((ROSThreadObjTest*) obj)->tenMultiplier();
         return NULL;
     }
 
-    void ten_multiplier()
+    void tenMultiplier()
     {
         int multiplier = 0;
 
@@ -88,20 +73,19 @@ private:
             sleep(0.02);
         }
 
-        safe_arithmetic("multiplication", multiplier);
+        safeArithmetic("multiplication", multiplier);
     }
 
     /**
      * Divides the value of var by 10 in 30 milliseconds
      */
-    static void* ten_divider_wrapper(void* obj)
+    static void* tenDividerWrapper(void* obj)
     {
-        ((ROSThreadObjTest*) obj)->ten_divider();
-
+        ((ROSThreadObjTest*) obj)->tenDivider();
         return NULL;
     }
 
-    void ten_divider()
+    void tenDivider()
     {
         int divider = 0;
 
@@ -111,23 +95,23 @@ private:
             sleep(0.03);
         }
 
-        safe_arithmetic("division", divider);
+        safeArithmetic("division", divider);
     }
 
     /**
      * adds 100 to the value of var in 10 seconds
      */
-    static void* slow_hundred_adder_wrapper(void* obj)
+    static void* slowHundredAdderWrapper(void* obj)
     {
-        ((ROSThreadObjTest*) obj)->slow_hundred_adder();
+        ((ROSThreadObjTest*) obj)->slowHundredAdder();
         return NULL;
     }
 
-    void slow_hundred_adder()
+    void slowHundredAdder()
     {
         for (size_t i = 0; i < 100; ++i)
         {
-            safe_arithmetic("addition", 1);
+            safeArithmetic("addition", 1);
             sleep(0.01);
         }
     }
@@ -146,7 +130,7 @@ public:
      *
      * @return the value of var
      */
-    int get_var()
+    int getVar()
     {
         std::lock_guard<std::mutex> lk(mtx);
         return var;
@@ -155,29 +139,26 @@ public:
     /**
     * pushes a specified function onto the functions vector
     * this is done indirectly by pushing the thread function wrapper
-    * @param func: the pointer to a thread entry function
+    *
+    * @param name pointer to a thread entry function
     */
-    bool add_function(const std::string& func_name)
+    bool addFunction(const std::string& _name)
     {
-        if(func_name == "print_var")
+        if     (_name ==         "tenAdder")
         {
-            functions.push_back(print_var_wrapper);
+            funcs.push_back(tenAdderWrapper);
         }
-        else if(func_name == "ten_adder")
+        else if(_name ==    "tenMultiplier")
         {
-            functions.push_back(ten_adder_wrapper);
+            funcs.push_back(tenMultiplierWrapper);
         }
-        else if(func_name == "ten_multiplier")
+        else if(_name ==       "tenDivider")
         {
-            functions.push_back(ten_multiplier_wrapper);
+            funcs.push_back(tenDividerWrapper);
         }
-        else if(func_name == "ten_divider")
+        else if(_name == "slowHundredAdder")
         {
-            functions.push_back(ten_divider_wrapper);
-        }
-        else if(func_name == "slow_hundred_adder")
-        {
-            functions.push_back(slow_hundred_adder_wrapper);
+            funcs.push_back(slowHundredAdderWrapper);
         }
         else
         {
@@ -195,10 +176,10 @@ public:
      *
      * @return: true/false if success/failure
      */
-    bool start_threads()
+    bool startThreads()
     {
         // condition to check each thread can be matched to a thread entry function
-        if(threads.size() != functions.size())
+        if(threads.size() != funcs.size())
         {
             return false;
         }
@@ -207,7 +188,7 @@ public:
         for (size_t i=0; i < threads.size(); ++i)
         {
             // passing this as an argument binds the thread function to an object instance
-            threads[i].start(functions[i], this);
+            threads[i].start(funcs[i], this);
         }
 
         return true;
@@ -216,12 +197,14 @@ public:
     /**
      * Joins each ROSThreadObj thread to the main thread in order
      */
-    void join_threads()
+    bool joinThreads()
     {
         for (size_t i=0; i < threads.size(); ++i)
         {
             threads[i].join();
         }
+
+        return true;
     }
 
     /**
@@ -229,7 +212,7 @@ public:
      *
      * @return: true/false if success/failure
      */
-    bool kill_threads()
+    bool killThreads()
     {
         for (size_t i=0; i < threads.size(); ++i)
         {
@@ -242,38 +225,38 @@ public:
 
 TEST(ROSThreadObjTest, testSingleThread)
 {
-    ROSThreadObjTest rtot(10);                    // create test object with var==10
-    EXPECT_TRUE(rtot.add_function("ten_adder"));  // push ten_adder onto functions vector
-    EXPECT_TRUE(rtot.start_threads());            // start the thread with matching function
-    rtot.join_threads();                          // join the thread to the main thread
-    EXPECT_EQ(20, rtot.get_var());                // check final value of var
+    ROSThreadObjTest rtot(10);                  // create test object with var==10
+    EXPECT_TRUE(rtot.addFunction("tenAdder"));  // push tenAdder onto functions vector
+    EXPECT_TRUE(rtot.startThreads());           // start the thread with matching function
+    EXPECT_TRUE(rtot.joinThreads());            // join the thread to the main thread
+    EXPECT_EQ(20, rtot.getVar());               // check final value of var
 }
 
 TEST(ROSThreadObjTest, testConcurrentThreads)
 {
     ROSThreadObjTest rtot(0);
-    EXPECT_TRUE(rtot.add_function("ten_adder"));
-    EXPECT_TRUE(rtot.add_function("ten_adder"));
-    EXPECT_TRUE(rtot.start_threads());
-    rtot.join_threads();
-    EXPECT_EQ(20, rtot.get_var());
+    EXPECT_TRUE(rtot.addFunction("tenAdder"));
+    EXPECT_TRUE(rtot.addFunction("tenAdder"));
+    EXPECT_TRUE(rtot.startThreads());
+    EXPECT_TRUE(rtot.joinThreads());
+    EXPECT_EQ(20, rtot.getVar());
 
     ROSThreadObjTest rtot2(100);
-    EXPECT_TRUE(rtot2.add_function("ten_multiplier"));
-    EXPECT_TRUE(rtot2.add_function("ten_divider"));
-    EXPECT_TRUE(rtot2.add_function("ten_divider"));
-    EXPECT_TRUE(rtot2.add_function("ten_multiplier"));
-    EXPECT_TRUE(rtot2.start_threads());
-    rtot2.join_threads();
-    EXPECT_EQ(100, rtot2.get_var());
+    EXPECT_TRUE(rtot2.addFunction("tenMultiplier"));
+    EXPECT_TRUE(rtot2.addFunction("tenDivider"));
+    EXPECT_TRUE(rtot2.addFunction("tenDivider"));
+    EXPECT_TRUE(rtot2.addFunction("tenMultiplier"));
+    EXPECT_TRUE(rtot2.startThreads());
+    EXPECT_TRUE(rtot2.joinThreads());
+    EXPECT_EQ(100, rtot2.getVar());
 
     ROSThreadObjTest rtot3(-50);
-    EXPECT_TRUE(rtot3.add_function("slow_hundred_adder"));
-    EXPECT_TRUE(rtot3.add_function("slow_hundred_adder"));
-    EXPECT_TRUE(rtot3.add_function("slow_hundred_adder"));
-    EXPECT_TRUE(rtot3.start_threads());
-    rtot3.join_threads();
-    EXPECT_EQ(250, rtot3.get_var());
+    EXPECT_TRUE(rtot3.addFunction("slowHundredAdder"));
+    EXPECT_TRUE(rtot3.addFunction("slowHundredAdder"));
+    EXPECT_TRUE(rtot3.addFunction("slowHundredAdder"));
+    EXPECT_TRUE(rtot3.startThreads());
+    EXPECT_TRUE(rtot3.joinThreads());
+    EXPECT_EQ(250, rtot3.getVar());
 }
 
 // Run all the tests that were declared with TEST()

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -1,0 +1,275 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "robot_utils/ros_thread_obj.h"
+
+#include <mutex>
+
+using namespace std;
+
+// pthreads prevent use of shared_ptr. So for now, mutex is needed for concurrent threads
+std::mutex m;
+
+/**
+ * the purpose of this class is to provide an object that can contain multiple ROSThreadObj
+ * as well as thread functions, and observe their combined effect on a shared variable
+ */
+class ROSThreadObjTest
+{
+private:
+    std::shared_ptr<int> var; // shared_ptr of an integer (to be modified by different threads)
+    std::vector<ROSThreadObj> threads; // a vector of ROSThreadObj to accept thread entry functions
+    std::vector<void *(*)(void *)> functions; // a vector of thread entry functions
+public:
+    /**
+     * constructors
+     * @param var_value: value of shared_ptr var
+     * @param threads_no: number of threads in the threads vector
+     * the default constructor creates an object with var_value==0 and threads_no==0
+     * both these arguments can be specified using the custom constructor
+     */
+    ROSThreadObjTest(): var(std::make_shared<int>(0)) {}
+    ROSThreadObjTest(int var_value, int threads_no): var(std::make_shared<int>(var_value))
+    {
+        for(int i=0; i < threads_no; i++)
+        {
+            threads.push_back(ROSThreadObj());
+        }
+    }
+
+    /**
+     * pushes a specified number (one by default) of threads onto the threads vector
+     * @param threads_no: number of threads to add
+     */
+    void add_thread(int threads_no=1)
+    {
+        for(int i=0; i < threads_no; i++)
+        {
+            threads.push_back(ROSThreadObj());
+        }
+    }
+
+    /**
+     * pushes a specified function onto the functions vector
+     * @param func: the pointer to a thread entry function
+     */
+    void add_function(void *(* func)(void *)) // accepts functions with void* input and output
+    {
+        functions.push_back(func);
+    }
+
+    /**
+    * @return: the value pointed to by the shared_ptr var
+    */
+    int var_value()
+    {
+        return *var;
+    }
+
+    /**
+    * @return: the reference/use count of the shared_ptr
+    */
+    int var_count()
+    {
+        return var.use_count();
+    }
+
+    /**
+     * starts each ROSThreadObj thread with matching thread entry function
+     * then joins all threads to the main thread in order
+     * @return: true if success, false if failure
+     */
+    bool start_threads()
+    {
+        // condition to check each thread can be matched to a thread entry function
+        if(threads.size() != functions.size())
+        {
+            return false;
+        }
+
+        // each thread is started with a corresponding thread entry function
+        for(int i=0, size=threads.size(); i < size; i++)
+        {
+            // the raw_ptr is retrieved from the shared_ptr for casting (according to pthread specs)
+            // and sent to the thread entry function
+            threads[i].start(functions[i], static_cast<void*>(var.get()));
+        }
+
+        return true;
+    }
+
+    /**
+     * joins each ROSThreadObj thread to the main thread in order
+     */
+    void join_threads()
+    {
+        for(int i=0, size=threads.size(); i < size; i++)
+        {
+            threads[i].join();
+        }
+    }
+
+    /**
+     * kills all running threads
+     * @return: true if success, false if failure
+     */
+    bool kill_threads()
+    {
+        for(int i=0, size=threads.size(); i < size; i++)
+        {
+            threads[i].kill();
+        }
+
+        return true;
+    }
+
+    /**
+     * Provides useful output for debugging
+     */
+    void test_info()
+    {
+        cout << "This ROSThreadObjTest object's address is: " << this << endl;
+        cout << "### VAR INFO ###" << endl;
+        cout << "*var is: " << *var << endl;
+        cout << "&var is: " << &var << endl;
+        cout << "var is: " << var << endl;
+        cout << "var.get() is: " << var.get() << endl;
+        cout << "### THREADS INFO ###" << endl;
+        cout << "The threads vector size is: " << threads.size() << endl;
+        cout << "The threads vector address is: " << &threads << endl;
+        cout << "threads[0] has a type: " << typeid(threads[0]).name() << endl;
+        cout << "### FUNCTIONS INFO ###" << endl;
+        cout << "The functions vector size is: " << functions.size() << endl;
+        cout << "functions[0] has a type: " << typeid(functions[0]).name() << endl;
+    }
+};
+
+/**
+ * thread entry function that prints the value of var
+ * @param var: the value pointed to by shared_ptr var
+ */
+void* print_var(void* var)
+{
+    auto var_instance = static_cast<int*>(var);
+    m.lock();
+    cout << *var_instance << endl;
+    m.unlock();
+    return (void*) 1;
+}
+
+/**
+ * thread entry function that adds 10 to the value of var in 10 milliseconds
+ * @param var: the value pointed to by shared_ptr var
+ */
+void* ten_adder(void* var)
+{
+    auto var_instance = static_cast<int*>(var);
+    m.lock();
+    for(int i = 0; i < 10; i++)
+    {
+        *var_instance = *var_instance + 1;
+        sleep(0.1);
+    }
+    m.unlock();
+    return (void*) 1;
+}
+
+/**
+ * thread entry function that multiplies the value of var by 10 in 20 milliseconds
+ * @param var: the value pointed to by shared_ptr var
+ */
+void* ten_multiplier(void* var)
+{
+    auto var_instance = static_cast<int*>(var);
+    int multiplier = 0;
+    m.lock();
+    for(int i = 0; i < 10; i++)
+    {
+        multiplier = multiplier + 1;
+        sleep(0.2);
+    }
+    *var_instance = *var_instance * multiplier;
+    m.unlock();
+    return (void*) 1;
+}
+
+/**
+ * thread entry function that divides the value of var by 10 in 30 milliseconds
+ * @param var: the value pointed to by shared_ptr var
+ */
+void* ten_divider(void* var)
+{
+    auto var_instance = static_cast<int*>(var);
+    int multiplier = 0;
+    m.lock();
+    for(int i = 0; i < 10; i++)
+    {
+        multiplier = multiplier + 1;
+        sleep(0.3);
+    }
+    *var_instance = *var_instance / multiplier; // careful: truncation
+    m.unlock();
+    return (void*) 1;
+}
+
+/**
+ * thread entry function that adds 100 to the value of var in 10 seconds
+ * @param var: the value pointed to by shared_ptr var
+ */
+void* slow_hundred_adder(void* var)
+{
+    auto var_instance = static_cast<int*>(var);
+    m.lock();
+    for(int i = 0; i < 100; i++)
+    {
+        *var_instance = *var_instance + 1;
+        sleep(0.1);
+    }
+    m.unlock();
+    return (void*) 1;
+}
+
+TEST(ROSThreadObjTest, testSingleThread)
+{
+    ROSThreadObjTest rtot(10, 0); // create a test object with value of var==0 and threads_no==0
+    rtot.add_function(ten_adder); // push ten_adder onto functions vector
+    rtot.add_thread(); // push a ROSThreadObj onto threads vector
+    rtot.start_threads(); // start the thread with matching function
+    rtot.join_threads(); // join the thread to the main thread
+    EXPECT_EQ(20, rtot.var_value()); // check final value of var
+}
+
+TEST(ROSThreadObjTest, testConcurrentThreads)
+{
+    ROSThreadObjTest rtot(0, 2);
+    rtot.add_function(ten_adder);
+    rtot.add_function(ten_adder);
+    rtot.start_threads();
+    rtot.join_threads();
+    EXPECT_EQ(20, rtot.var_value());
+
+    ROSThreadObjTest rtot2(100, 4);
+    rtot2.add_function(ten_multiplier);
+    rtot2.add_function(ten_divider);
+    rtot2.add_function(ten_divider);
+    rtot2.add_function(ten_multiplier);
+    rtot2.start_threads();
+    rtot2.join_threads();
+    EXPECT_EQ(100, rtot2.var_value());
+
+    ROSThreadObjTest rtot3(-50, 3);
+    rtot3.add_function(slow_hundred_adder);
+    rtot3.add_function(slow_hundred_adder);
+    rtot3.add_function(slow_hundred_adder);
+    rtot3.start_threads();
+    rtot3.join_threads();
+    EXPECT_EQ(250, rtot3.var_value());
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "test_ros_thread_obj");
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -12,6 +12,7 @@ using namespace std;
  */
 class ROSThreadObjTest
 {
+
 private:
     int var;                                    // variable to be modified by different threads
     std::mutex mtx;                             // mutex for controlled thread access
@@ -19,127 +20,24 @@ private:
     std::vector<ROSThreadObj>        threads;   // vector of ROSThreadObj
     std::vector<void *(*)(void *)> functions;   // vector of thread entry functions
 
-public:
-
-    /**
-     * Class constructor
-     *
-     * @param _var: value of var (default 0)
-     * @param _n_threads: number of threads in the threads vector (default 0)
-     */
-    ROSThreadObjTest(int _var=0, size_t _n_threads=0) : var(_var)
-    {
-        for (size_t i=0; i < _n_threads; ++i)
-        {
-            threads.push_back(ROSThreadObj());
-        }
-    }
-
-    /**
-     * Pushes a specified number of threads onto the threads vector
-     *
-     * @param _n_threads number of threads to add (default 1)
-     */
-    void add_thread(size_t _n_threads=1)
-    {
-        for (size_t i=0; i < _n_threads; ++i)
-        {
-            threads.push_back(ROSThreadObj());
-        }
-    }
-
     /**
      * Does an arithmetic operation on the value of var thread-safely
      */
     bool safe_arithmetic(const std::string& operation, int arg)
     {
         std::lock_guard<std::mutex> lk(mtx);
-        if(operation=="addition")
-        {
-            var = var + arg;
-        }
-        else if(operation=="subtraction")
-        {
-            var = var - arg;
-        }
-        else if(operation=="division")
-        {
-            var = var / arg; // careful: truncation
-        }
-        else if(operation=="multiplication")
-        {
-            var = var * arg;
-        }
-        else
-        {
-            return false; // no valid operation
-        }
-        return true;
-    }
 
-    /**
-     * Gets the value of var thread-safely
-     *
-     * @return the value of var
-     */
-    int get_var()
-    {
-        std::lock_guard<std::mutex> lk(mtx);
-        return var;
-    }
-
-    /**
-     * Starts each ROSThreadObj thread with matching thread entry function,
-     * then joins all threads to the main thread in order
-     *
-     * @return: true/false if success/failure
-     */
-    bool start_threads()
-    {
-        // condition to check each thread can be matched to a thread entry function
-        if(threads.size() != functions.size())
-        {
-            return false;
-        }
-
-        // each thread is started with a corresponding thread entry function
-        for (size_t i=0, size=threads.size(); i < size; ++i)
-        {
-            // passing this as an argument binds the thread function to an object instance
-            threads[i].start(functions[i], this);
-        }
+        if     (operation=="addition")       {   var += arg; }
+        else if(operation=="subtraction")    {   var -= arg; }
+        else if(operation=="division")       {   var /= arg; }
+        else if(operation=="multiplication") {   var *= arg; }
+        else                                 { return false; }
 
         return true;
     }
 
     /**
-     * Joins each ROSThreadObj thread to the main thread in order
-     */
-    void join_threads()
-    {
-        for (size_t i=0, size=threads.size(); i < size; ++i)
-        {
-            threads[i].join();
-        }
-    }
-
-    /**
-     * Kills all running threads
-     *
-     * @return: true/false if success/failure
-     */
-    bool kill_threads()
-    {
-        for (size_t i=0, size=threads.size(); i < size; ++i)
-        {
-            threads[i].kill();
-        }
-
-        return true;
-    }
-
-    /**
-     * Thread entry function that prints the value of var
+     * Prints the value of var
      */
     static void* print_var_wrapper(void* obj)
     {
@@ -148,16 +46,13 @@ public:
         return NULL;
     }
 
-    /**
-     * Prints the variable to stdout
-     */
     void print_var()
     {
         cout << get_var() << endl;
     }
 
     /**
-     * Thread entry function that adds 10 to the value of var in 10 milliseconds
+     * Adds 10 to the value of var in 10 milliseconds
      */
     static void* ten_adder_wrapper(void* obj)
     {
@@ -165,18 +60,17 @@ public:
         return NULL;
     }
 
-
     void ten_adder()
     {
         for (size_t i = 0; i < 10; ++i)
         {
             safe_arithmetic("addition", 1);
-            sleep(0.1);
+            sleep(0.01);
         }
     }
 
     /**
-     * Thread entry function that multiplies the value of var by 10 in 20 milliseconds
+     * Multiplies the value of var by 10 in 20 milliseconds
      */
     static void* ten_multiplier_wrapper(void* obj)
     {
@@ -191,14 +85,14 @@ public:
         for (size_t i = 0; i < 10; ++i)
         {
             multiplier = multiplier + 1;
-            sleep(0.2);
+            sleep(0.02);
         }
 
         safe_arithmetic("multiplication", multiplier);
     }
 
     /**
-     * Thread entry function that divides the value of var by 10 in 30 milliseconds
+     * Divides the value of var by 10 in 30 milliseconds
      */
     static void* ten_divider_wrapper(void* obj)
     {
@@ -214,14 +108,14 @@ public:
         for (size_t i = 0; i < 10; ++i)
         {
             divider = divider + 1;
-            sleep(0.3);
+            sleep(0.03);
         }
 
         safe_arithmetic("division", divider);
     }
 
     /**
-     * Thread entry function that adds 100 to the value of var in 10 seconds
+     * adds 100 to the value of var in 10 seconds
      */
     static void* slow_hundred_adder_wrapper(void* obj)
     {
@@ -234,8 +128,28 @@ public:
         for (size_t i = 0; i < 100; ++i)
         {
             safe_arithmetic("addition", 1);
-            sleep(0.1);
+            sleep(0.01);
         }
+    }
+
+public:
+
+    /**
+     * Class constructor
+     *
+     * @param _var: value of var (default 0)
+     */
+    ROSThreadObjTest(int _var = 0) : var(_var) {}
+
+    /**
+     * Gets the value of var thread-safely
+     *
+     * @return the value of var
+     */
+    int get_var()
+    {
+        std::lock_guard<std::mutex> lk(mtx);
+        return var;
     }
 
     /**
@@ -270,43 +184,94 @@ public:
             return false;
         }
 
+        threads.push_back(ROSThreadObj());
+
+        return true;
+    }
+
+    /**
+     * Starts each ROSThreadObj thread with matching thread entry function,
+     * then joins all threads to the main thread in order
+     *
+     * @return: true/false if success/failure
+     */
+    bool start_threads()
+    {
+        // condition to check each thread can be matched to a thread entry function
+        if(threads.size() != functions.size())
+        {
+            return false;
+        }
+
+        // each thread is started with a corresponding thread entry function
+        for (size_t i=0; i < threads.size(); ++i)
+        {
+            // passing this as an argument binds the thread function to an object instance
+            threads[i].start(functions[i], this);
+        }
+
+        return true;
+    }
+
+    /**
+     * Joins each ROSThreadObj thread to the main thread in order
+     */
+    void join_threads()
+    {
+        for (size_t i=0; i < threads.size(); ++i)
+        {
+            threads[i].join();
+        }
+    }
+
+    /**
+     * Kills all running threads
+     *
+     * @return: true/false if success/failure
+     */
+    bool kill_threads()
+    {
+        for (size_t i=0; i < threads.size(); ++i)
+        {
+            threads[i].kill();
+        }
+
         return true;
     }
 };
 
 TEST(ROSThreadObjTest, testSingleThread)
 {
-    ROSThreadObjTest rtot(10, 0);       // create test object with var==10 and threads_no==0
-    rtot.add_function("ten_adder");     // push ten_adder onto functions vector
-    rtot.add_thread();                  // push a ROSThreadObj onto threads vector
-    rtot.start_threads();               // start the thread with matching function
-    rtot.join_threads();                // join the thread to the main thread
-    EXPECT_EQ(20, rtot.get_var());      // check final value of var
+    ROSThreadObjTest rtot(10);                    // create test object with var==10
+    EXPECT_TRUE(rtot.add_function("ten_adder"));  // push ten_adder onto functions vector
+    EXPECT_TRUE(rtot.start_threads());            // start the thread with matching function
+    rtot.join_threads();                          // join the thread to the main thread
+    EXPECT_EQ(20, rtot.get_var());                // check final value of var
 }
 
 TEST(ROSThreadObjTest, testConcurrentThreads)
 {
-    ROSThreadObjTest rtot(0, 2);
-    rtot.add_function("ten_adder");
-    rtot.add_function("ten_adder");
-    rtot.start_threads();
+    ROSThreadObjTest rtot(0);
+    EXPECT_TRUE(rtot.add_function("ten_adder"));
+    EXPECT_TRUE(rtot.add_function("ten_adder"));
+    EXPECT_TRUE(rtot.start_threads());
     rtot.join_threads();
     EXPECT_EQ(20, rtot.get_var());
 
-    ROSThreadObjTest rtot2(100, 4);
-    rtot2.add_function("ten_multiplier");
-    rtot2.add_function("ten_divider");
-    rtot2.add_function("ten_divider");
-    rtot2.add_function("ten_multiplier");
-    rtot2.start_threads();
+    ROSThreadObjTest rtot2(100);
+    EXPECT_TRUE(rtot2.add_function("ten_multiplier"));
+    EXPECT_TRUE(rtot2.add_function("ten_divider"));
+    EXPECT_TRUE(rtot2.add_function("ten_divider"));
+    EXPECT_TRUE(rtot2.add_function("ten_multiplier"));
+    EXPECT_TRUE(rtot2.start_threads());
     rtot2.join_threads();
     EXPECT_EQ(100, rtot2.get_var());
 
-    ROSThreadObjTest rtot3(-50, 3);
-    rtot3.add_function("slow_hundred_adder");
-    rtot3.add_function("slow_hundred_adder");
-    rtot3.add_function("slow_hundred_adder");
-    rtot3.start_threads();
+    ROSThreadObjTest rtot3(-50);
+    EXPECT_TRUE(rtot3.add_function("slow_hundred_adder"));
+    EXPECT_TRUE(rtot3.add_function("slow_hundred_adder"));
+    EXPECT_TRUE(rtot3.add_function("slow_hundred_adder"));
+    EXPECT_TRUE(rtot3.start_threads());
     rtot3.join_threads();
     EXPECT_EQ(250, rtot3.get_var());
 }

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -17,9 +17,10 @@ std::mutex m;
 class ROSThreadObjTest
 {
 private:
-    std::shared_ptr<int> var; // shared_ptr of an integer (to be modified by different threads)
-    std::vector<ROSThreadObj> threads; // a vector of ROSThreadObj to accept thread entry functions
-    std::vector<void *(*)(void *)> functions; // a vector of thread entry functions
+    std::shared_ptr<int> var;                   // integer to be modified by different threads
+    std::vector<ROSThreadObj> threads;          // a vector of ROSThreadObj to accept thread entry functions
+    std::vector<void *(*)(void *)> functions;   // a vector of thread entry functions
+
 public:
     /**
      * constructors
@@ -90,8 +91,8 @@ public:
         // each thread is started with a corresponding thread entry function
         for(int i=0, size=threads.size(); i < size; i++)
         {
-            // the raw_ptr is retrieved from the shared_ptr for casting (according to pthread specs)
-            // and sent to the thread entry function
+            // the raw_ptr is retrieved from the shared_ptr for casting
+            // (according to pthread specs) and sent to the thread entry function
             threads[i].start(functions[i], static_cast<void*>(var.get()));
         }
 
@@ -231,12 +232,12 @@ void* slow_hundred_adder(void* var)
 
 TEST(ROSThreadObjTest, testSingleThread)
 {
-    ROSThreadObjTest rtot(10, 0); // create a test object with value of var==0 and threads_no==0
-    rtot.add_function(ten_adder); // push ten_adder onto functions vector
-    rtot.add_thread(); // push a ROSThreadObj onto threads vector
-    rtot.start_threads(); // start the thread with matching function
-    rtot.join_threads(); // join the thread to the main thread
-    EXPECT_EQ(20, rtot.var_value()); // check final value of var
+    ROSThreadObjTest rtot(10, 0);       // create a test object with var==10 and threads_no==0
+    rtot.add_function(ten_adder);       // push ten_adder onto functions vector
+    rtot.add_thread();                  // push a ROSThreadObj onto threads vector
+    rtot.start_threads();               // start the thread with matching function
+    rtot.join_threads();                // join the thread to the main thread
+    EXPECT_EQ(20, rtot.var_value());    // check final value of var
 }
 
 TEST(ROSThreadObjTest, testConcurrentThreads)

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -77,8 +77,7 @@ public:
         // each thread is started with a corresponding thread entry function
         for(int i=0, size=threads.size(); i < size; i++)
         {
-            // the raw_ptr is retrieved from the shared_ptr for casting
-            // (according to pthread specs) and sent to the thread entry function
+            // passing this as an argument binds the thread function to an object instance
             threads[i].start(functions[i], this);
         }
 
@@ -222,9 +221,10 @@ public:
 
     /**
     * pushes a specified function onto the functions vector
+    * this is done indirectly by pushing the thread function wrapper
     * @param func: the pointer to a thread entry function
     */
-    bool add_function(const std::string& func_name) // accepts functions with void* input and output
+    bool add_function(const std::string& func_name)
     {
         if(func_name == "print_var")
         {
@@ -244,7 +244,6 @@ public:
         }
         else if(func_name == "slow_hundred_adder")
         {
-            //std::function<void*(void*)> f = &ROSThreadObjTest::slow_hundred_adder;
             functions.push_back(slow_hundred_adder_wrapper);
         }
         else

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -123,7 +123,7 @@ public:
      *
      * @param _var: value of var (default 0)
      */
-    ROSThreadObjTest(int _var = 0) : var(_var) {}
+    explicit ROSThreadObjTest(int _var = 0) : var(_var) {}
 
     /**
      * Gets the value of var thread-safely

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -13,46 +13,43 @@ using namespace std;
 class ROSThreadObjTest
 {
 private:
-    int var;                                    // integer to be modified by different threads
-    std::vector<ROSThreadObj> threads;          // a vector of ROSThreadObj to accept thread entry functions
-    std::vector<void *(*)(void *)> functions;   // a vector of thread entry functions
+    int var;                                    // variable to be modified by different threads
     std::mutex mtx;                             // mutex for controlled thread access
 
+    std::vector<ROSThreadObj>        threads;   // vector of ROSThreadObj
+    std::vector<void *(*)(void *)> functions;   // vector of thread entry functions
+
 public:
+
     /**
-     * constructors
-     * @param var_value: value of var
-     * @param threads_no: number of threads in the threads vector
-     * the default constructor creates an object with var_value==0 and threads_no==0
-     * both these arguments can be specified using the custom constructor
+     * Class constructor
+     *
+     * @param _var: value of var (default 0)
+     * @param _n_threads: number of threads in the threads vector (default 0)
      */
-    ROSThreadObjTest()
+    ROSThreadObjTest(int _var=0, size_t _n_threads=0) : var(_var)
     {
-        var = 0;
-    }
-    ROSThreadObjTest(int var_value, int threads_no)
-    {
-        var = var_value;
-        for(int i=0; i < threads_no; i++)
+        for (size_t i=0; i < _n_threads; ++i)
         {
             threads.push_back(ROSThreadObj());
         }
     }
 
     /**
-     * pushes a specified number (one by default) of threads onto the threads vector
-     * @param threads_no: number of threads to add
+     * Pushes a specified number of threads onto the threads vector
+     *
+     * @param _n_threads number of threads to add (default 1)
      */
-    void add_thread(int threads_no=1)
+    void add_thread(size_t _n_threads=1)
     {
-        for(int i=0; i < threads_no; i++)
+        for (size_t i=0; i < _n_threads; ++i)
         {
             threads.push_back(ROSThreadObj());
         }
     }
 
     /**
-     * does an arithmetic operation on the value of var thread-safely
+     * Does an arithmetic operation on the value of var thread-safely
      */
     bool safe_arithmetic(const std::string& operation, int arg)
     {
@@ -81,8 +78,10 @@ public:
     }
 
     /**
-    * @return: gets the value of var thread-safely
-    */
+     * Gets the value of var thread-safely
+     *
+     * @return the value of var
+     */
     int get_var()
     {
         std::lock_guard<std::mutex> lk(mtx);
@@ -90,9 +89,10 @@ public:
     }
 
     /**
-     * starts each ROSThreadObj thread with matching thread entry function
+     * Starts each ROSThreadObj thread with matching thread entry function,
      * then joins all threads to the main thread in order
-     * @return: true if success, false if failure
+     *
+     * @return: true/false if success/failure
      */
     bool start_threads()
     {
@@ -103,7 +103,7 @@ public:
         }
 
         // each thread is started with a corresponding thread entry function
-        for(int i=0, size=threads.size(); i < size; i++)
+        for (size_t i=0, size=threads.size(); i < size; ++i)
         {
             // passing this as an argument binds the thread function to an object instance
             threads[i].start(functions[i], this);
@@ -113,23 +113,24 @@ public:
     }
 
     /**
-     * joins each ROSThreadObj thread to the main thread in order
+     * Joins each ROSThreadObj thread to the main thread in order
      */
     void join_threads()
     {
-        for(int i=0, size=threads.size(); i < size; i++)
+        for (size_t i=0, size=threads.size(); i < size; ++i)
         {
             threads[i].join();
         }
     }
 
     /**
-     * kills all running threads
-     * @return: true if success, false if failure
+     * Kills all running threads
+     *
+     * @return: true/false if success/failure
      */
     bool kill_threads()
     {
-        for(int i=0, size=threads.size(); i < size; i++)
+        for (size_t i=0, size=threads.size(); i < size; ++i)
         {
             threads[i].kill();
         }
@@ -138,29 +139,36 @@ public:
     }
 
     /**
-     * thread entry function that prints the value of var
+     * Thread entry function that prints the value of var
      */
     static void* print_var_wrapper(void* obj)
     {
         ((ROSThreadObjTest*) obj)->print_var();
+
         return NULL;
     }
+
+    /**
+     * Prints the variable to stdout
+     */
     void print_var()
     {
         cout << get_var() << endl;
     }
 
     /**
-     * thread entry function that adds 10 to the value of var in 10 milliseconds
+     * Thread entry function that adds 10 to the value of var in 10 milliseconds
      */
     static void* ten_adder_wrapper(void* obj)
     {
         ((ROSThreadObjTest*) obj)->ten_adder();
         return NULL;
     }
+
+
     void ten_adder()
     {
-        for(int i = 0; i < 10; i++)
+        for (size_t i = 0; i < 10; ++i)
         {
             safe_arithmetic("addition", 1);
             sleep(0.1);
@@ -168,54 +176,62 @@ public:
     }
 
     /**
-     * thread entry function that multiplies the value of var by 10 in 20 milliseconds
+     * Thread entry function that multiplies the value of var by 10 in 20 milliseconds
      */
     static void* ten_multiplier_wrapper(void* obj)
     {
         ((ROSThreadObjTest*) obj)->ten_multiplier();
         return NULL;
     }
+
     void ten_multiplier()
     {
         int multiplier = 0;
-        for(int i = 0; i < 10; i++)
+
+        for (size_t i = 0; i < 10; ++i)
         {
             multiplier = multiplier + 1;
             sleep(0.2);
         }
+
         safe_arithmetic("multiplication", multiplier);
     }
 
     /**
-     * thread entry function that divides the value of var by 10 in 30 milliseconds
+     * Thread entry function that divides the value of var by 10 in 30 milliseconds
      */
     static void* ten_divider_wrapper(void* obj)
     {
         ((ROSThreadObjTest*) obj)->ten_divider();
+
         return NULL;
     }
+
     void ten_divider()
     {
-        int multiplier = 0;
-        for(int i = 0; i < 10; i++)
+        int divider = 0;
+
+        for (size_t i = 0; i < 10; ++i)
         {
-            multiplier = multiplier + 1;
+            divider = divider + 1;
             sleep(0.3);
         }
-        safe_arithmetic("division", multiplier);
+
+        safe_arithmetic("division", divider);
     }
 
     /**
-     * thread entry function that adds 100 to the value of var in 10 seconds
+     * Thread entry function that adds 100 to the value of var in 10 seconds
      */
     static void* slow_hundred_adder_wrapper(void* obj)
     {
         ((ROSThreadObjTest*) obj)->slow_hundred_adder();
         return NULL;
     }
+
     void slow_hundred_adder()
     {
-        for(int i = 0; i < 100; i++)
+        for (size_t i = 0; i < 100; ++i)
         {
             safe_arithmetic("addition", 1);
             sleep(0.1);
@@ -253,18 +269,19 @@ public:
         {
             return false;
         }
+
         return true;
     }
 };
 
 TEST(ROSThreadObjTest, testSingleThread)
 {
-    ROSThreadObjTest rtot(10, 0);       // create a test object with var==10 and threads_no==0
+    ROSThreadObjTest rtot(10, 0);       // create test object with var==10 and threads_no==0
     rtot.add_function("ten_adder");     // push ten_adder onto functions vector
     rtot.add_thread();                  // push a ROSThreadObj onto threads vector
     rtot.start_threads();               // start the thread with matching function
     rtot.join_threads();                // join the thread to the main thread
-    EXPECT_EQ(20, rtot.get_var());    // check final value of var
+    EXPECT_EQ(20, rtot.get_var());      // check final value of var
 }
 
 TEST(ROSThreadObjTest, testConcurrentThreads)

--- a/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_obj.cpp
@@ -49,7 +49,7 @@ private:
     {
         for (size_t i = 0; i < 10; ++i)
         {
-            safeArithmetic("addition", 1);
+            EXPECT_TRUE(safeArithmetic("addition", 1));
             sleep(0.01);
         }
     }
@@ -65,15 +65,7 @@ private:
 
     void tenMultiplier()
     {
-        int multiplier = 0;
-
-        for (size_t i = 0; i < 10; ++i)
-        {
-            multiplier = multiplier + 1;
-            sleep(0.02);
-        }
-
-        safeArithmetic("multiplication", multiplier);
+        EXPECT_TRUE(safeArithmetic("multiplication", 10));
     }
 
     /**
@@ -87,15 +79,7 @@ private:
 
     void tenDivider()
     {
-        int divider = 0;
-
-        for (size_t i = 0; i < 10; ++i)
-        {
-            divider = divider + 1;
-            sleep(0.03);
-        }
-
-        safeArithmetic("division", divider);
+        EXPECT_TRUE(safeArithmetic("division", 10));
     }
 
     /**
@@ -111,7 +95,7 @@ private:
     {
         for (size_t i = 0; i < 100; ++i)
         {
-            safeArithmetic("addition", 1);
+            EXPECT_TRUE(safeArithmetic("addition", 1));
             sleep(0.01);
         }
     }
@@ -144,26 +128,11 @@ public:
     */
     bool addFunction(const std::string& _name)
     {
-        if     (_name ==         "tenAdder")
-        {
-            funcs.push_back(tenAdderWrapper);
-        }
-        else if(_name ==    "tenMultiplier")
-        {
-            funcs.push_back(tenMultiplierWrapper);
-        }
-        else if(_name ==       "tenDivider")
-        {
-            funcs.push_back(tenDividerWrapper);
-        }
-        else if(_name == "slowHundredAdder")
-        {
-            funcs.push_back(slowHundredAdderWrapper);
-        }
-        else
-        {
-            return false;
-        }
+        if     (_name ==         "tenAdder") { funcs.push_back(tenAdderWrapper);         }
+        else if(_name ==    "tenMultiplier") { funcs.push_back(tenMultiplierWrapper);    }
+        else if(_name ==       "tenDivider") { funcs.push_back(tenDividerWrapper);       }
+        else if(_name == "slowHundredAdder") { funcs.push_back(slowHundredAdderWrapper); }
+        else                                 {                             return false; }
 
         threads.push_back(ROSThreadObj());
 
@@ -174,15 +143,12 @@ public:
      * Starts each ROSThreadObj thread with matching thread entry function,
      * then joins all threads to the main thread in order
      *
-     * @return: true/false if success/failure
+     * @return true/false if success/failure
      */
     bool startThreads()
     {
         // condition to check each thread can be matched to a thread entry function
-        if(threads.size() != funcs.size())
-        {
-            return false;
-        }
+        if(threads.size() != funcs.size()) { return false; }
 
         // each thread is started with a corresponding thread entry function
         for (size_t i=0; i < threads.size(); ++i)
@@ -196,6 +162,8 @@ public:
 
     /**
      * Joins each ROSThreadObj thread to the main thread in order
+     *
+     * @return always true
      */
     bool joinThreads()
     {
@@ -210,7 +178,7 @@ public:
     /**
      * Kills all running threads
      *
-     * @return: true/false if success/failure
+     * @return true/false if success/failure
      */
     bool killThreads()
     {


### PR DESCRIPTION
made a new branch because the other one started to get messy

for now,  i used a mutex to lock and unlock the thread functions as needed to address the concurrency issue. hopefully when switching to shared-ptr with std::threads it may not be required.