### PR TITLE
updated arm ctrl to work without ROS thread

### DIFF
--- a/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
+++ b/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
@@ -82,7 +82,7 @@ bool HoldCtrl::waitForUserFb(double _wait_time)
     ros::Time _init = ros::Time::now();
 
     ros::Rate(THREAD_FREQ);
-    while(RobotInterface::ok() && not getIsClosing())
+    while(RobotInterface::ok() && not isClosing())
     {
         if (cuff_button_pressed == true)        return true;
 

--- a/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
+++ b/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
@@ -82,7 +82,7 @@ bool HoldCtrl::waitForUserFb(double _wait_time)
     ros::Time _init = ros::Time::now();
 
     ros::Rate(THREAD_FREQ);
-    while(RobotInterface::ok())
+    while(RobotInterface::ok() && not getIsClosing())
     {
         if (cuff_button_pressed == true)        return true;
 

--- a/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
+++ b/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
@@ -2,8 +2,9 @@
 #define __ARM_CONTROLLER_H__
 
 #include <map>
+#include <thread>
+#include <mutex>
 
-#include "robot_utils/ros_thread.h"
 #include "robot_interface/robot_interface.h"
 #include "robot_interface/gripper.h"
 
@@ -14,7 +15,7 @@
 #define HAND_OVER_DONE   "handover_done"
 #define HAND_OVER_WAIT   "handover_wait"
 
-class ArmCtrl : public RobotInterface, public Gripper, public ROSThread
+class ArmCtrl : public RobotInterface, public Gripper
 {
 private:
     // Substate of the controller (useful to keep track of
@@ -60,6 +61,8 @@ private:
      * itself in human terms.
      */
     std::map<int, std::string> object_db;
+
+    std::thread arm_thread; // internal thread functionality
 
     /**
      * Provides basic functionalities for the object, such as a goHome and releaseObject.
@@ -364,6 +367,11 @@ public:
      * Destructor
      */
     virtual ~ArmCtrl();
+
+    /**
+     * Starts thread that executes the control server.
+     */
+    bool startThread();
 
     /**
      * Callback for the service that requests actions

--- a/baxter_collaboration_lib/include/robot_interface/robot_interface.h
+++ b/baxter_collaboration_lib/include/robot_interface/robot_interface.h
@@ -119,8 +119,8 @@ private:
      */
     std::thread ctrl_thread; // Internal thread that implements the controller server
 
-    bool ctrl_thread_close_flag;              // Flag to close the thread entry function
-    std::mutex mtx_ctrl_thread_close_flag;    // Mutex to protect the thread close flag
+    bool is_closing;              // Flag to close the thread entry function
+    std::mutex mtx_is_closing;    // Mutex to protect the thread close flag
 
     ros::Subscriber ctrl_sub;   // Subscriber that receives desired poses from other nodes
     ros::Publisher  rviz_pub;   // Published that publishes the current target on rviz
@@ -634,8 +634,8 @@ public:
     /**
      * Safely manipulate the boolean needed to kill the thread entry
      */
-    void setCtrlThreadCloseFlag(bool arg);
-    bool getCtrlThreadCloseFlag();
+    void setIsClosing(bool arg);
+    bool getIsClosing();
 };
 
 #endif

--- a/baxter_collaboration_lib/include/robot_interface/robot_interface.h
+++ b/baxter_collaboration_lib/include/robot_interface/robot_interface.h
@@ -119,8 +119,8 @@ private:
      */
     std::thread ctrl_thread; // Internal thread that implements the controller server
 
-    bool is_closing;              // Flag to close the thread entry function
-    std::mutex mtx_is_closing;    // Mutex to protect the thread close flag
+    bool           is_closing;  // Flag to close the thread entry function
+    std::mutex mtx_is_closing;  // Mutex to protect the thread close flag
 
     ros::Subscriber ctrl_sub;   // Subscriber that receives desired poses from other nodes
     ros::Publisher  rviz_pub;   // Published that publishes the current target on rviz
@@ -635,7 +635,7 @@ public:
      * Safely manipulate the boolean needed to kill the thread entry
      */
     void setIsClosing(bool arg);
-    bool getIsClosing();
+    bool isClosing();
 };
 
 #endif

--- a/baxter_collaboration_lib/src/robot_interface/arm_ctrl.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/arm_ctrl.cpp
@@ -417,7 +417,7 @@ bool ArmCtrl::moveArm(string dir, double dist, string mode, bool disable_coll_av
     bool finish = false;
 
     ros::Rate r(100);
-    while(RobotInterface::ok() && !isPositionReached(p_f, mode) && not getIsClosing())
+    while(RobotInterface::ok() && !isPositionReached(p_f, mode) && not isClosing())
     {
         if (disable_coll_av)    suppressCollisionAv();
 
@@ -517,7 +517,7 @@ bool ArmCtrl::homePoseStrict(bool disable_coll_av)
     ROS_INFO("[%s] Going to home position strict..", getLimb().c_str());
 
     ros::Rate r(100);
-    while(RobotInterface::ok() && !isConfigurationReached(home_conf) && not getIsClosing())
+    while(RobotInterface::ok() && !isConfigurationReached(home_conf) && not isClosing())
     {
         if (disable_coll_av)    suppressCollisionAv();
 

--- a/baxter_collaboration_lib/src/robot_interface/arm_ctrl.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/arm_ctrl.cpp
@@ -417,7 +417,7 @@ bool ArmCtrl::moveArm(string dir, double dist, string mode, bool disable_coll_av
     bool finish = false;
 
     ros::Rate r(100);
-    while(RobotInterface::ok() && !isPositionReached(p_f, mode))
+    while(RobotInterface::ok() && !isPositionReached(p_f, mode) && not getIsClosing())
     {
         if (disable_coll_av)    suppressCollisionAv();
 
@@ -517,7 +517,7 @@ bool ArmCtrl::homePoseStrict(bool disable_coll_av)
     ROS_INFO("[%s] Going to home position strict..", getLimb().c_str());
 
     ros::Rate r(100);
-    while(RobotInterface::ok() && !isConfigurationReached(home_conf))
+    while(RobotInterface::ok() && !isConfigurationReached(home_conf) && not getIsClosing())
     {
         if (disable_coll_av)    suppressCollisionAv();
 
@@ -649,5 +649,6 @@ bool ArmCtrl::publishState()
 
 ArmCtrl::~ArmCtrl()
 {
+    setIsClosing(false);
     if (arm_thread.joinable()) { arm_thread.join(); }
 }

--- a/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
@@ -106,7 +106,7 @@ void RobotInterface::ThreadEntry()
 {
     ros::Rate r(ctrl_freq);
 
-    while (ros::ok() && not getIsClosing())
+    while (ros::ok() && not isClosing())
     {
         // ROS_INFO("Time: %g", (ros::Time::now() - initTime).toSec());
 
@@ -202,7 +202,7 @@ void RobotInterface::setIsClosing(bool arg)
     is_closing = arg;
 }
 
-bool RobotInterface::getIsClosing()
+bool RobotInterface::isClosing()
 {
     std::lock_guard<std::mutex> lck(mtx_is_closing);
     return is_closing;
@@ -626,7 +626,7 @@ bool RobotInterface::goToPose(double px, double py, double pz,
     if (!computeIK(px, py, pz, ox, oy, oz, ow, joint_angles)) return false;
 
     ros::Rate r(100);
-    while (RobotInterface::ok() && not getIsClosing())
+    while (RobotInterface::ok() && not isClosing())
     {
         if (disable_coll_av)
         {
@@ -998,7 +998,7 @@ bool RobotInterface::waitForForceInteraction(double _wait_time, bool disable_col
     ros::Time _init = ros::Time::now();
 
     ros::Rate r(100);
-    while (RobotInterface::ok() && not getIsClosing())
+    while (RobotInterface::ok() && not isClosing())
     {
         if (disable_coll_av)          suppressCollisionAv();
         if (detectForceInteraction())           return true;

--- a/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
@@ -626,7 +626,7 @@ bool RobotInterface::goToPose(double px, double py, double pz,
     if (!computeIK(px, py, pz, ox, oy, oz, ow, joint_angles)) return false;
 
     ros::Rate r(100);
-    while (RobotInterface::ok())
+    while (RobotInterface::ok() && not getIsClosing())
     {
         if (disable_coll_av)
         {
@@ -998,7 +998,7 @@ bool RobotInterface::waitForForceInteraction(double _wait_time, bool disable_col
     ros::Time _init = ros::Time::now();
 
     ros::Rate r(100);
-    while (RobotInterface::ok())
+    while (RobotInterface::ok() && not getIsClosing())
     {
         if (disable_coll_av)          suppressCollisionAv();
         if (detectForceInteraction())           return true;

--- a/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
@@ -14,7 +14,7 @@ RobotInterface::RobotInterface(string _name, string _limb, bool _use_robot, doub
                                ir_ok(false), curr_range(0.0), curr_min_range(0.0), curr_max_range(0.0),
                                ik_solver(_limb, _use_robot), use_trac_ik(_use_trac_ik), ctrl_freq(_ctrl_freq),
                                filt_force{0.0, 0.0, 0.0}, filt_change{0.0, 0.0, 0.0}, time_filt_last_updated(ros::Time::now()),
-                               is_coll_av_on(false), is_coll_det_on(false), ctrl_thread_close_flag(false), use_cart_ctrl(_use_cart_ctrl),
+                               is_coll_av_on(false), is_coll_det_on(false), is_closing(false), use_cart_ctrl(_use_cart_ctrl),
                                is_ctrl_running(false), is_experimental(_is_experimental),
                                ctrl_mode(baxter_collaboration_msgs::GoToPose::POSITION_MODE), ctrl_check_mode("strict"), ctrl_type("pose")
 {
@@ -106,7 +106,7 @@ void RobotInterface::ThreadEntry()
 {
     ros::Rate r(ctrl_freq);
 
-    while (ros::ok() && not getCtrlThreadCloseFlag())
+    while (ros::ok() && not getIsClosing())
     {
         // ROS_INFO("Time: %g", (ros::Time::now() - initTime).toSec());
 
@@ -196,16 +196,16 @@ void RobotInterface::ThreadEntry()
     return;
 }
 
-void RobotInterface::setCtrlThreadCloseFlag(bool arg)
+void RobotInterface::setIsClosing(bool arg)
 {
-    std::lock_guard<std::mutex> lck(mtx_ctrl_thread_close_flag);
-    ctrl_thread_close_flag = arg;
+    std::lock_guard<std::mutex> lck(mtx_is_closing);
+    is_closing = arg;
 }
 
-bool RobotInterface::getCtrlThreadCloseFlag()
+bool RobotInterface::getIsClosing()
 {
-    std::lock_guard<std::mutex> lck(mtx_ctrl_thread_close_flag);
-    return ctrl_thread_close_flag;
+    std::lock_guard<std::mutex> lck(mtx_is_closing);
+    return is_closing;
 }
 
 bool RobotInterface::ok()
@@ -1094,7 +1094,7 @@ void RobotInterface::suppressCollisionAv()
 
 RobotInterface::~RobotInterface()
 {
-    setCtrlThreadCloseFlag(true);
+    setIsClosing(true);
     if (ctrl_thread.joinable())
     {
         ctrl_thread.join();


### PR DESCRIPTION
In this case, the `is_closing` flag and mutex was not needed because there was no looping of the thread function. The unit tests were successful.