### PR TITLE
Improvements to Gripper class and addition of gripper keyboard

### DIFF
--- a/baxter_collaboration/CMakeLists.txt
+++ b/baxter_collaboration/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(modular_action_provider  src/modular_furniture/tool_picker.h
                                         src/modular_furniture/part_picker.cpp
                                         src/modular_furniture/action_provider.cpp)
 add_executable(baxter_display           src/baxter_display.cpp)
+add_executable(gripper_keyboard         src/gripper_keyboard.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
@@ -103,6 +104,7 @@ target_link_libraries(tower_action_provider                        ${catkin_LIBR
 target_link_libraries(hsv_detector                                 ${catkin_LIBRARIES} )
 target_link_libraries(modular_action_provider   flatpack_furniture ${catkin_LIBRARIES} )
 target_link_libraries(baxter_display            ${OpenCV_LIBS}     ${catkin_LIBRARIES} )
+target_link_libraries(gripper_keyboard                             ${catkin_LIBRARIES} )
 
 #############
 ## Install ##

--- a/baxter_collaboration/CMakeLists.txt
+++ b/baxter_collaboration/CMakeLists.txt
@@ -80,7 +80,6 @@ add_executable(modular_action_provider  src/modular_furniture/tool_picker.h
                                         src/modular_furniture/part_picker.cpp
                                         src/modular_furniture/action_provider.cpp)
 add_executable(baxter_display           src/baxter_display.cpp)
-add_executable(gripper_keyboard         src/gripper_keyboard.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
@@ -104,7 +103,6 @@ target_link_libraries(tower_action_provider                        ${catkin_LIBR
 target_link_libraries(hsv_detector                                 ${catkin_LIBRARIES} )
 target_link_libraries(modular_action_provider   flatpack_furniture ${catkin_LIBRARIES} )
 target_link_libraries(baxter_display            ${OpenCV_LIBS}     ${catkin_LIBRARIES} )
-target_link_libraries(gripper_keyboard                             ${catkin_LIBRARIES} )
 
 #############
 ## Install ##

--- a/baxter_collaboration/baxter_collaboration/controller.py
+++ b/baxter_collaboration/baxter_collaboration/controller.py
@@ -124,7 +124,7 @@ class BaseController(object):
 
     def _stop(self):
         if not self.finished:
-            rospy.loginfo('Stopping policy controller')
+            rospy.loginfo('Stopping controller')
             self.timer.log('Stop')
             rospy.loginfo(str(self.timer.data))
             self.timer.save()
@@ -134,10 +134,14 @@ class BaseController(object):
         self.finished = True
         self._abort_waiting_suscribers()
         self._home()
+	rospy.signal_shutdown("controller shutdown")
 
     def _abort_waiting_suscribers(self):
         self.answer_sub.listening = False
         self.error_sub.listening = False
+        self.error_sub.listening = False
+        self.left_button_sub.listening = False
+        self.right_button_sub.listening = False
 
     def run(self):
         try:

--- a/baxter_collaboration/lib/src/flatpack_furniture/artag_ctrl.cpp
+++ b/baxter_collaboration/lib/src/flatpack_furniture/artag_ctrl.cpp
@@ -44,7 +44,7 @@ bool ARTagCtrl::getObject()
     if (!hoverAbovePool())          return false;
     ros::Duration(0.05).sleep();
     if (!pickARTag())               return false;
-    if (!gripObject())              return false;
+    if (!close())                   return false;
     if (!moveArm("up", 0.4))        return false;
     if (!homePoseStrict())          return false;
 
@@ -57,7 +57,7 @@ bool ARTagCtrl::passObject()
     if (!moveObjectTowardHuman())       return false;
     ros::Duration(1.0).sleep();
     if (!waitForForceInteraction())     return false;
-    if (!releaseObject())               return false;
+    if (!open())                        return false;
     if (!homePoseStrict())              return false;
 
     return true;
@@ -78,7 +78,7 @@ bool ARTagCtrl::recoverRelease()
     if(!homePoseStrict())                   return false;
     ros::Duration(0.05).sleep();
     if (!pickARTag())                       return false;
-    if (!gripObject())                      return false;
+    if (!close())                           return false;
     if (!moveArm("up", 0.2))                return false;
     if (!homePoseStrict())                  return false;
 
@@ -88,7 +88,7 @@ bool ARTagCtrl::recoverRelease()
 bool ARTagCtrl::recoverGet()
 {
     if (!hoverAbovePool())          return false;
-    if (!releaseObject())           return false;
+    if (!open())                    return false;
     if (!homePoseStrict())          return false;
 
     return true;
@@ -101,7 +101,7 @@ bool ARTagCtrl::handOver()
     ros::Duration(0.2).sleep();
     if (!waitForOtherArm(30.0, true))   return false;
     ros::Duration(0.8).sleep();
-    if (!releaseObject())               return false;
+    if (!open())                        return false;
     if (!moveArm("up", 0.05))           return false;
     if (!homePoseStrict())              return false;
     setSubState("");

--- a/baxter_collaboration/lib/src/flatpack_furniture/artag_ctrl.cpp
+++ b/baxter_collaboration/lib/src/flatpack_furniture/artag_ctrl.cpp
@@ -239,7 +239,7 @@ bool ARTagCtrl::pickARTag()
         }
         else
         {
-            cnt_ik_fail++;
+            ++cnt_ik_fail;
         }
 
         if (cnt_ik_fail == 10)      return false;

--- a/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
+++ b/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
@@ -1,9 +1,9 @@
 #include "flatpack_furniture/hold_ctrl.h"
 
-using namespace std;
+using namespace              std;
 using namespace baxter_core_msgs;
 
-HoldCtrl::HoldCtrl(std::string _name, std::string _limb, bool _use_robot) :
+HoldCtrl::HoldCtrl(string _name, string _limb, bool _use_robot) :
                    ArmCtrl(_name,_limb, _use_robot), cuff_button_pressed(false)
 {
     setHomeConfiguration();
@@ -39,7 +39,7 @@ bool HoldCtrl::handOver()
     if (!goHoldPose(0.24))                return false;
     // ros::Duration(1.0).sleep();
     // if (!waitForForceInteraction(180.0))  return false;
-    // if (!open())                       return false;
+    // if (!open())                          return false;
     // ros::Duration(1.0).sleep();
     // if (!homePoseStrict())         return false;
     setSubState("");

--- a/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
+++ b/baxter_collaboration/lib/src/flatpack_furniture/hold_ctrl.cpp
@@ -34,12 +34,12 @@ bool HoldCtrl::handOver()
     if (!prepare4HandOver())              return false;
     setSubState(HAND_OVER_READY);
     if (!waitForOtherArm(120.0, true))    return false;
-    if (!gripObject())                    return false;
+    if (!close())                         return false;
     ros::Duration(1.2).sleep();
     if (!goHoldPose(0.24))                return false;
     // ros::Duration(1.0).sleep();
     // if (!waitForForceInteraction(180.0))  return false;
-    // if (!releaseObject())                 return false;
+    // if (!open())                       return false;
     // ros::Duration(1.0).sleep();
     // if (!homePoseStrict())         return false;
     setSubState("");
@@ -55,7 +55,7 @@ bool HoldCtrl::startHold()
     if (!goHoldPose(0.30))              return false;
     ros::Duration(1.0).sleep();
     if (!waitForUserFb(time))           return false;
-    if (!gripObject())                  return false;
+    if (!close())                       return false;
     ros::Duration(1.0).sleep();
 
     return true;
@@ -66,7 +66,7 @@ bool HoldCtrl::endHold()
     double time=getObjectIDs().size()>=2?getObjectIDs()[1]:180.0;
 
     if (!waitForUserFb(time))           return false;
-    if (!releaseObject())               return false;
+    if (!open())                        return false;
     ros::Duration(1.0).sleep();
     if (!homePoseStrict())              return false;
     return true;

--- a/baxter_collaboration/scripts/supportive.py
+++ b/baxter_collaboration/scripts/supportive.py
@@ -31,8 +31,8 @@ args = parser.parse_args(sys.argv[1:])
 
 
 # Algorithm parameters
-N_WARMUP = 20
-ITERATIONS = 800
+N_WARMUP = 100
+ITERATIONS = 20
 EXPLORATION = 50
 RELATIVE_EXPLO = False  # In this case use smaller exploration
 BELIEF_VALUES = False

--- a/baxter_collaboration/scripts/supportive.py
+++ b/baxter_collaboration/scripts/supportive.py
@@ -10,7 +10,7 @@ import argparse
 from task_models.task import (SequentialCombination, LeafCombination)
 from task_models.supportive import (SupportivePOMDP, AssembleLeg, AssembleLegToTop,
                                     NHTMHorizon)
-from task_models.lib.pomdp import AsyncPOMCPPolicyRunner, export_pomcp
+from task_models.lib.pomcp import AsyncPOMCPPolicyRunner, export_pomcp
 from task_models.lib.belief import format_belief_array
 
 import rospy
@@ -52,6 +52,8 @@ class UnexpectedActionFailure(RuntimeError):
 
 
 class POMCPController(BaseController):
+
+    NODE_NAME = "supportive_controller"
 
     OBJECTS_LEFT = "action_provider/objects_left"
     OBJECTS_RIGHT = "action_provider/objects_right"

--- a/baxter_collaboration/scripts/supportive.py
+++ b/baxter_collaboration/scripts/supportive.py
@@ -223,32 +223,36 @@ p.r_subtask = 0.
 p.r_preference = 20.
 p.cost_hold = 3.
 p.cost_get = 20.
-pol = AsyncPOMCPPolicyRunner(p, iterations=ITERATIONS,
-                             horizon=NHTMHorizon.generator(p, n=HORIZON),
-                             exploration=EXPLORATION,
-                             relative_exploration=RELATIVE_EXPLO,
-                             belief_values=BELIEF_VALUES,
-                             belief='particle',
-                             belief_params={'n_particles': N_PARTICLES})
+try:
+    pol = AsyncPOMCPPolicyRunner(p, iterations=ITERATIONS,
+                                 horizon=NHTMHorizon.generator(p, n=HORIZON),
+                                 exploration=EXPLORATION,
+                                 relative_exploration=RELATIVE_EXPLO,
+                                 belief_values=BELIEF_VALUES,
+                                 belief='particle',
+                                 belief_params={'n_particles': N_PARTICLES})
 
-# Warm up policy
-best = None
-maxl = 0
-for i in range(N_WARMUP):
-    s = 'Exploring... [{:2.0f}%] (current best: {} [{:.1f}])'.format(
-        i * 100. / N_WARMUP, best, pol.tree.root.children[pol._last_action].value
-        if pol._last_action is not None else 0.0)
-    maxl = max(maxl, len(s))
-    print(' ' * maxl, end='\r')
-    print(s, end='\r')
-    sys.stdout.flush()
-    best = pol.get_action()  # Some exploration
-print('Exploring... [done]')
-if BELIEF_VALUES:
-    print('Found {} distinct beliefs.'.format(len(pol.tree._obs_nodes)))
+    # Warm up policy
+    best = None
+    maxl = 0
+    for i in range(N_WARMUP):
+        s = 'Exploring... [{:2.0f}%] (current best: {} [{:.1f}])'.format(
+            i * 100. / N_WARMUP, best, pol.tree.root.children[pol._last_action].value
+            if pol._last_action is not None else 0.0)
+        maxl = max(maxl, len(s))
+        print(' ' * maxl, end='\r')
+        print(s, end='\r')
+        sys.stdout.flush()
+        best = pol.get_action()  # Some exploration
+    print('Exploring... [done]')
+    if BELIEF_VALUES:
+        print('Found {} distinct beliefs.'.format(len(pol.tree._obs_nodes)))
 
-export_pomcp(pol, EXPORT_DEST, belief_as_quotient=EXPORT_BELIEF_QUOTIENT)
-print('Saved: ' + EXPORT_DEST)
+    export_pomcp(pol, EXPORT_DEST, belief_as_quotient=EXPORT_BELIEF_QUOTIENT)
+    print('Saved: ' + EXPORT_DEST)
+except KeyboardInterrupt:
+    pol.stop()
+    raise
 
 try:
     input("Press enter to start...")

--- a/baxter_collaboration/scripts/supportive.py
+++ b/baxter_collaboration/scripts/supportive.py
@@ -256,18 +256,23 @@ try:
 		     args=(pol, EXPORT_DEST),
                      kwargs={"belief_as_quotient": EXPORT_BELIEF_QUOTIENT})
     p_save.start()
+
+    try:
+        input("Press enter to start...")
+    except Exception:
+        pass
+
+    timer_path = os.path.join(args.path, 'timer-{}.json'.format(args.user))
+    controller = POMCPController(pol, timer_path=timer_path, recovery=True)
+
 except KeyboardInterrupt:
     pol.stop()
     raise
 
-try:
-    input("Press enter to start...")
-except Exception:
-    pass
-
-timer_path = os.path.join(args.path, 'timer-{}.json'.format(args.user))
-controller = POMCPController(pol, timer_path=timer_path, recovery=True)
 controller.run()
 pol.execute(export_pomcp, pol, EXPORT_DEST,
             belief_as_quotient=EXPORT_BELIEF_QUOTIENT)
-p_save.join()
+
+if p_save.is_alive():
+    p_save.terminate()
+p_save.join(.1)

--- a/baxter_collaboration/scripts/supportive.py
+++ b/baxter_collaboration/scripts/supportive.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 import argparse
+from multiprocessing import Process
 
 from task_models.task import (SequentialCombination, LeafCombination)
 from task_models.supportive import (SupportivePOMDP, AssembleLeg, AssembleLegToTop,
@@ -211,6 +212,7 @@ class POMCPController(BaseController):
             return self.model.observations[self.model.O_NONE]
 
 
+
 # Problem definition
 leg_i = 'leg-{}'.format
 htm = SequentialCombination([
@@ -250,8 +252,10 @@ try:
     if BELIEF_VALUES:
         print('Found {} distinct beliefs.'.format(len(pol.tree._obs_nodes)))
 
-    export_pomcp(pol, EXPORT_DEST, belief_as_quotient=EXPORT_BELIEF_QUOTIENT)
-    print('Saved: ' + EXPORT_DEST)
+    p_save = Process(target=export_pomcp,
+		     args=(pol, EXPORT_DEST),
+                     kwargs={"belief_as_quotient": EXPORT_BELIEF_QUOTIENT})
+    p_save.start()
 except KeyboardInterrupt:
     pol.stop()
     raise
@@ -266,3 +270,4 @@ controller = POMCPController(pol, timer_path=timer_path, recovery=True)
 controller.run()
 pol.execute(export_pomcp, pol, EXPORT_DEST,
             belief_as_quotient=EXPORT_BELIEF_QUOTIENT)
+p_save.join()

--- a/baxter_collaboration/src/gripper_keyboard.cpp
+++ b/baxter_collaboration/src/gripper_keyboard.cpp
@@ -11,29 +11,32 @@ int main(int argc, char** argv)
     left_gripper = new Gripper("left");
     right_gripper = new Gripper("right");
 
+    ROS_INFO("You are now controlling the robot grippers");
+
     // gripper keys
     while(ros::ok())
     {
-        ROS_INFO("Enter your command...");
+        ROS_INFO("Enter your command (or press ? for help)...");
 
         char c = std::cin.get();
-        ROS_INFO("Key entered: %c", c);
         std::cin.ignore();
+        ROS_INFO("Key entered: %c", c);
 
         switch(c)
         {
         case '?':
             ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
-            ROS_INFO("q : close gripper");
-            ROS_INFO("w : open gripper");
-            ROS_INFO("z : is gripper enabled?");
-            ROS_INFO("x : is gripper calibrated?");
-            ROS_INFO("c : is gripper ready to grip?");
-            ROS_INFO("v : does gripper have error?");
-            ROS_INFO("b : is gripper sucking?");
-            ROS_INFO("n : is gripper gripping?");
+            ROS_INFO("q / Q : close gripper");
+            ROS_INFO("w / W : open gripper");
+            ROS_INFO("z / Z : is gripper enabled?");
+            ROS_INFO("x / X: is gripper calibrated?");
+            ROS_INFO("c / C: is gripper ready to grip?");
+            ROS_INFO("v / V: does gripper have error?");
+            ROS_INFO("b / B: is gripper sucking?");
+            ROS_INFO("n / N: is gripper gripping?");
             ROS_INFO("? : help");
             ROS_INFO("e : exit");
+            break;
         case 'q':
             ROS_INFO("Closing left gripper");
             left_gripper->gripObject();

--- a/baxter_collaboration/src/gripper_keyboard.cpp
+++ b/baxter_collaboration/src/gripper_keyboard.cpp
@@ -55,12 +55,10 @@ int main(int argc, char** argv)
             right_gripper->releaseObject();
             break;
         case 't':
-            ROS_INFO("Left gripper type:");
-            left_gripper->type();
+            ROS_INFO("Left gripper type: %s", left_gripper->type().c_str());
             break;
         case 'T':
-            ROS_INFO("Right gripper type:");
-            right_gripper->type();
+            ROS_INFO("Right gripper type: %s", right_gripper->type().c_str());
             break;
         case 'z':
             ROS_INFO("Is left enabled? %s", (left_gripper->is_enabled()? "Yes" : "No"));

--- a/baxter_collaboration/src/gripper_keyboard.cpp
+++ b/baxter_collaboration/src/gripper_keyboard.cpp
@@ -1,0 +1,105 @@
+#include "robot_interface/gripper.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "gripper_keyboard");
+    ros::AsyncSpinner spinner(1);
+    spinner.start();
+
+    // gripper instantiation
+    Gripper *left_gripper = NULL, *right_gripper = NULL;
+    left_gripper = new Gripper("left");
+    right_gripper = new Gripper("right");
+
+    // gripper keys
+    while(ros::ok())
+    {
+        ROS_INFO("Enter your command...");
+
+        char c = std::cin.get();
+        ROS_INFO("Key entered: %c", c);
+        std::cin.ignore();
+
+        switch(c)
+        {
+        case '?':
+            ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
+            ROS_INFO("q : close gripper");
+            ROS_INFO("w : open gripper");
+            ROS_INFO("z : is gripper enabled?");
+            ROS_INFO("x : is gripper calibrated?");
+            ROS_INFO("c : is gripper ready to grip?");
+            ROS_INFO("v : does gripper have error?");
+            ROS_INFO("b : is gripper sucking?");
+            ROS_INFO("n : is gripper gripping?");
+            ROS_INFO("? : help");
+            ROS_INFO("e : exit");
+        case 'q':
+            ROS_INFO("Closing left gripper");
+            left_gripper->gripObject();
+            break;
+        case 'Q':
+            ROS_INFO("Closing right gripper");
+            right_gripper->gripObject();
+            break;
+        case 'w':
+            ROS_INFO("Opening left gripper");
+            left_gripper->releaseObject();
+            break;
+        case 'W':
+            ROS_INFO("Opening right gripper");
+            right_gripper->releaseObject();
+            break;
+        case 'z':
+            ROS_INFO("Is left enabled? %s", (left_gripper->is_enabled()? "Yes" : "No"));
+            break;
+        case 'Z':
+            ROS_INFO("Is right enabled? %s", (right_gripper->is_enabled()? "Yes" : "No"));
+            break;
+        case 'x':
+            ROS_INFO("Is left calibrated? %s", left_gripper->is_calibrated()? "Yes" : "No");
+            break;
+        case 'X':
+            ROS_INFO("Is right calibrated? %s", right_gripper->is_calibrated()? "Yes" : "No");
+            break;
+        case 'c':
+            ROS_INFO("Is left ready to grip? %s", left_gripper->is_ready_to_grip()? "Yes" : "No");
+            break;
+        case 'C':
+            ROS_INFO("Is right ready to grip? %s", right_gripper->is_ready_to_grip()? "Yes" : "No");
+            break;
+        case 'v':
+            ROS_INFO("Does left have error? %s", left_gripper->has_error()? "Yes" : "No");
+            break;
+        case 'V':
+            ROS_INFO("Does right have error? %s", right_gripper->has_error()? "Yes" : "No");
+            break;
+        case 'b':
+            ROS_INFO("Is left sucking? %s", left_gripper->is_sucking()? "Yes" : "No");
+            break;
+        case 'B':
+            ROS_INFO("Is right sucking? %s", right_gripper->is_sucking()? "Yes" : "No");
+            break;
+        case 'n':
+            ROS_INFO("Is left gripping? %s", left_gripper->is_gripping()? "Yes" : "No");
+            break;
+        case 'N':
+            ROS_INFO("Is right gripping? %s", right_gripper->is_gripping()? "Yes" : "No");
+            break;
+        case 'e':
+            ROS_INFO("Exiting...");
+            return 0;
+        default:
+            ROS_INFO("Not a valid command. Press ? for help, e to exit.");
+            break;
+        }
+        ros::spinOnce();
+    }
+
+    delete left_gripper;
+    delete right_gripper;
+    left_gripper = right_gripper = 0;
+
+    return 0;
+}
+

--- a/baxter_collaboration/src/gripper_keyboard.cpp
+++ b/baxter_collaboration/src/gripper_keyboard.cpp
@@ -40,19 +40,19 @@ int main(int argc, char** argv)
             break;
         case 'q':
             ROS_INFO("Closing left gripper");
-            left_gripper->gripObject();
+            left_gripper->close();
             break;
         case 'Q':
             ROS_INFO("Closing right gripper");
-            right_gripper->gripObject();
+            right_gripper->close();
             break;
         case 'w':
             ROS_INFO("Opening left gripper");
-            left_gripper->releaseObject();
+            left_gripper->open();
             break;
         case 'W':
             ROS_INFO("Opening right gripper");
-            right_gripper->releaseObject();
+            right_gripper->open();
             break;
         case 't':
             ROS_INFO("Left gripper type: %s", left_gripper->type().c_str());

--- a/baxter_collaboration/src/gripper_keyboard.cpp
+++ b/baxter_collaboration/src/gripper_keyboard.cpp
@@ -28,13 +28,15 @@ int main(int argc, char** argv)
             ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
             ROS_INFO("q / Q : close gripper");
             ROS_INFO("w / W : open gripper");
+            ROS_INFO("c / C : calibrate gripper");
+            ROS_INFO("x / X : is gripper calibrated?");
+            ROS_INFO("d / D : clear calibration");
             ROS_INFO("t / T : type of gripper");
             ROS_INFO("z / Z : is gripper enabled?");
-            ROS_INFO("x / X : is gripper calibrated?");
-            ROS_INFO("c / C : is gripper ready to grip?");
             ROS_INFO("v / V : does gripper have error?");
             ROS_INFO("b / B : is gripper sucking?");
             ROS_INFO("n / N : is gripper gripping?");
+            ROS_INFO("m / M : is gripper ready to grip?");
             ROS_INFO("? : help");
             ROS_INFO("e : exit");
             break;
@@ -54,6 +56,28 @@ int main(int argc, char** argv)
             ROS_INFO("Opening right gripper");
             right_gripper->open();
             break;
+        case 'c':
+            ROS_INFO("Calibrating left gripper");
+            left_gripper->calibrate();
+            break;
+        case 'C':
+            ROS_INFO("Calibrating right gripper");
+            right_gripper->calibrate();
+            break;
+        case 'x':
+            ROS_INFO("Is left calibrated? %s", left_gripper->is_calibrated()? "Yes" : "No");
+            break;
+        case 'X':
+            ROS_INFO("Is right calibrated? %s", right_gripper->is_calibrated()? "Yes" : "No");
+            break;
+        case 'd':
+            ROS_INFO("Clear left gripper calibration");
+            left_gripper->clearCalibration();
+            break;
+        case 'D':
+            ROS_INFO("Clear right gripper calibration");
+            right_gripper->clearCalibration();
+            break;
         case 't':
             ROS_INFO("Left gripper type: %s", left_gripper->type().c_str());
             break;
@@ -65,18 +89,6 @@ int main(int argc, char** argv)
             break;
         case 'Z':
             ROS_INFO("Is right enabled? %s", (right_gripper->is_enabled()? "Yes" : "No"));
-            break;
-        case 'x':
-            ROS_INFO("Is left calibrated? %s", left_gripper->is_calibrated()? "Yes" : "No");
-            break;
-        case 'X':
-            ROS_INFO("Is right calibrated? %s", right_gripper->is_calibrated()? "Yes" : "No");
-            break;
-        case 'c':
-            ROS_INFO("Is left ready to grip? %s", left_gripper->is_ready_to_grip()? "Yes" : "No");
-            break;
-        case 'C':
-            ROS_INFO("Is right ready to grip? %s", right_gripper->is_ready_to_grip()? "Yes" : "No");
             break;
         case 'v':
             ROS_INFO("Does left have error? %s", left_gripper->has_error()? "Yes" : "No");
@@ -95,6 +107,12 @@ int main(int argc, char** argv)
             break;
         case 'N':
             ROS_INFO("Is right gripping? %s", right_gripper->is_gripping()? "Yes" : "No");
+            break;
+        case 'm':
+            ROS_INFO("Is left ready to grip? %s", left_gripper->is_ready_to_grip()? "Yes" : "No");
+            break;
+        case 'M':
+            ROS_INFO("Is right ready to grip? %s", right_gripper->is_ready_to_grip()? "Yes" : "No");
             break;
         case 'e':
             ROS_INFO("Exiting...");

--- a/baxter_collaboration/src/gripper_keyboard.cpp
+++ b/baxter_collaboration/src/gripper_keyboard.cpp
@@ -28,12 +28,13 @@ int main(int argc, char** argv)
             ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
             ROS_INFO("q / Q : close gripper");
             ROS_INFO("w / W : open gripper");
+            ROS_INFO("t / T : type of gripper");
             ROS_INFO("z / Z : is gripper enabled?");
-            ROS_INFO("x / X: is gripper calibrated?");
-            ROS_INFO("c / C: is gripper ready to grip?");
-            ROS_INFO("v / V: does gripper have error?");
-            ROS_INFO("b / B: is gripper sucking?");
-            ROS_INFO("n / N: is gripper gripping?");
+            ROS_INFO("x / X : is gripper calibrated?");
+            ROS_INFO("c / C : is gripper ready to grip?");
+            ROS_INFO("v / V : does gripper have error?");
+            ROS_INFO("b / B : is gripper sucking?");
+            ROS_INFO("n / N : is gripper gripping?");
             ROS_INFO("? : help");
             ROS_INFO("e : exit");
             break;
@@ -52,6 +53,14 @@ int main(int argc, char** argv)
         case 'W':
             ROS_INFO("Opening right gripper");
             right_gripper->releaseObject();
+            break;
+        case 't':
+            ROS_INFO("Left gripper type:");
+            left_gripper->type();
+            break;
+        case 'T':
+            ROS_INFO("Right gripper type:");
+            right_gripper->type();
             break;
         case 'z':
             ROS_INFO("Is left enabled? %s", (left_gripper->is_enabled()? "Yes" : "No"));

--- a/baxter_collaboration/src/modular_furniture/part_picker.cpp
+++ b/baxter_collaboration/src/modular_furniture/part_picker.cpp
@@ -34,7 +34,7 @@ bool PartPicker::passObject()
         ros::Duration(0.25).sleep();
     }
 
-    if (!releaseObject())               return false;
+    if (!open())                        return false;
     if (!homePoseStrict())              return false;
 
     return true;

--- a/baxter_collaboration/src/modular_furniture/tool_picker.cpp
+++ b/baxter_collaboration/src/modular_furniture/tool_picker.cpp
@@ -1,13 +1,13 @@
 #include "tool_picker.h"
 
-using namespace std;
+using namespace              std;
 using namespace baxter_core_msgs;
 
 #define VERTICAL_ORI_R2         0.1, 1.0, 0.0, 0.0
 
-ToolPicker::ToolPicker(std::string _name, std::string _limb, bool _use_robot) :
-                       HoldCtrl(_name,_limb, _use_robot), CartesianEstimatorClient(_name, _limb),
-                       elap_time(0)
+ToolPicker::ToolPicker(string _name, string _limb, bool _use_robot) :
+                       HoldCtrl(_name,_limb, _use_robot),
+                       CartesianEstimatorClient(_name, _limb), elap_time(0)
 {
     setHomeConfiguration();
 
@@ -20,8 +20,8 @@ ToolPicker::ToolPicker(std::string _name, std::string _limb, bool _use_robot) :
 
     removeAction(ACTION_HOLD);
 
-    insertAction(std::string(ACTION_HOLD) + "_leg", static_cast<f_action>(&ToolPicker::holdObject));
-    insertAction(std::string(ACTION_HOLD) + "_top", static_cast<f_action>(&ToolPicker::holdObject));
+    insertAction(string(ACTION_HOLD) + "_leg", static_cast<f_action>(&ToolPicker::holdObject));
+    insertAction(string(ACTION_HOLD) + "_top", static_cast<f_action>(&ToolPicker::holdObject));
 
     printActionDB();
 
@@ -220,7 +220,10 @@ bool ToolPicker::pickUpObject()
 
             r.sleep();
         }
-        else    cnt_ik_fail++;
+        else
+        {
+            ++cnt_ik_fail;
+        }
 
         if (cnt_ik_fail == 10)  return false;
     }
@@ -320,7 +323,7 @@ bool ToolPicker::computeOrientation(geometry_msgs::Quaternion &_q)
     return true;
 }
 
-int ToolPicker::chooseObjectID(std::vector<int> _objs)
+int ToolPicker::chooseObjectID(vector<int> _objs)
 {
     if (getSubState() != CHECK_OBJ_IDS)
     {
@@ -342,17 +345,17 @@ int ToolPicker::chooseObjectID(std::vector<int> _objs)
         return res;
     }
 
-    std::vector<string> objs_str;
+    vector<string> objs_str;
     for (size_t i = 0; i < _objs.size(); ++i)
     {
         objs_str.push_back(getObjectNameFromDB(_objs[i]));
     }
 
-    std::vector<string> av_objects = getAvailableObjects(objs_str);
+    vector<string> av_objects = getAvailableObjects(objs_str);
 
     if (av_objects.size() == 0)     return res;
 
-    std::srand(std::time(0)); //use current time as seed
+    srand(time(0)); //use current time as seed
     string res_str = av_objects[rand() % av_objects.size()];
 
     res = getObjectIDFromDB(res_str);
@@ -393,7 +396,7 @@ void ToolPicker::reduceSquish()
 void ToolPicker::resetSquish()
 {
     XmlRpc::XmlRpcValue squish_params;
-    for (std::vector<int>::size_type i = 0; i != squish_thresholds.size(); i++)
+    for (vector<int>::size_type i = 0; i != squish_thresholds.size(); ++i)
     {
         // rewrite the squish parameters from the initial squish thresholds stored in reduceSquish()
         squish_params[i] = squish_thresholds[i];
@@ -412,7 +415,7 @@ bool ToolPicker::goHoldPose(double height)
 {
     ROS_INFO("[%s] Going to %s position..", getLimb().c_str(), getAction().c_str());
 
-    if (getAction() == std::string(ACTION_HOLD) + "_top")
+    if (getAction() == string(ACTION_HOLD) + "_top")
     {
         return goToPose(0.72, -0.31, 0.032, 0.54, 0.75, 0.29,0.22);
     }

--- a/baxter_collaboration/src/modular_furniture/tool_picker.cpp
+++ b/baxter_collaboration/src/modular_furniture/tool_picker.cpp
@@ -48,7 +48,7 @@ bool ToolPicker::getObject()
     }
 
     if (!pickUpObject())            return false;
-    if (!gripObject())              return false;
+    if (!close())                   return false;
     if (!moveArm("up", 0.3))        return false;
     // if (!hoverAboveTable(Z_LOW))    return false;
 
@@ -64,7 +64,7 @@ bool ToolPicker::passObject()
         if (!goToPose(0.85, -0.26, 0.27,
                       HORIZONTAL_ORI_R))    return false;
         if (!waitForUserFb())               return false;
-        if (!releaseObject())               return false;
+        if (!open())                        return false;
     }
     else if (CartesianEstimatorClient::getObjectName() == "screws_box"  ||
              CartesianEstimatorClient::getObjectName() == "brackets_box")
@@ -81,7 +81,7 @@ bool ToolPicker::passObject()
         }
 
         ros::Duration(0.25).sleep();
-        if (!releaseObject())           return false;
+        if (!open())                    return false;
         if (!hoverAboveTable(Z_LOW))    return false;
     }
 
@@ -121,7 +121,7 @@ bool ToolPicker::cleanUpObject()
     }
 
     if (!pickUpObject())            return false;
-    if (!gripObject())              return false;
+    if (!close())                   return false;
     if (!moveArm("up", 0.3))        return false;
     if (!homePoseStrict())          return false;
 
@@ -139,7 +139,7 @@ bool ToolPicker::cleanUpObject()
     }
 
     ros::Duration(0.25).sleep();
-    if (!releaseObject())           return false;
+    if (!open())                    return false;
     if (!homePoseStrict())          return false;
 
     return true;

--- a/baxter_collaboration/src/tower_building/cube_picker.cpp
+++ b/baxter_collaboration/src/tower_building/cube_picker.cpp
@@ -41,7 +41,7 @@ bool CubePicker::pickObject()
     if (!homePoseStrict())          return false;
     ros::Duration(0.05).sleep();
     if (!pickARTag())               return false;
-    if (!gripObject())              return false;
+    if (!close())                   return false;
     if (!moveArm("up", 0.3))        return false;
     if (!hoverAboveTable(Z_LOW))    return false;
 
@@ -54,7 +54,7 @@ bool CubePicker::passObject()
     if (!moveObjectTowardHuman())       return false;
     ros::Duration(1.0).sleep();
     if (!waitForForceInteraction())     return false;
-    if (!releaseObject())               return false;
+    if (!open())                        return false;
     if (!homePoseStrict())              return false;
 
     return true;
@@ -77,7 +77,7 @@ bool CubePicker::recoverPickPass()
     {
         if (!moveArm("left", 0.1)) return false;
         if (!moveArm("down", 0.3)) return false;
-        if (!releaseObject())      return false;
+        if (!open())               return false;
         if (!homePoseStrict()) return false;
     }
     return true;

--- a/baxter_collaboration/src/tower_building/cube_picker.cpp
+++ b/baxter_collaboration/src/tower_building/cube_picker.cpp
@@ -4,7 +4,8 @@ using namespace std;
 using namespace baxter_core_msgs;
 
 CubePicker::CubePicker(std::string _name, std::string _limb, bool _use_robot) :
-                       ArmCtrl(_name,_limb, _use_robot), ARucoClient(_name, _limb), elap_time(0)
+                       ArmCtrl(_name,_limb, _use_robot),
+                       ARucoClient(_name, _limb), elap_time(0)
 {
     setHomeConfiguration();
 
@@ -13,7 +14,8 @@ CubePicker::CubePicker(std::string _name, std::string _limb, bool _use_robot) :
     insertAction(ACTION_GET,       static_cast<f_action>(&CubePicker::pickObject));
     insertAction(ACTION_PASS,      static_cast<f_action>(&CubePicker::passObject));
     insertAction(ACTION_GET_PASS,  static_cast<f_action>(&CubePicker::pickPassObject));
-    insertAction("recover_"+string(ACTION_GET_PASS), static_cast<f_action>(&CubePicker::recoverPickPass));
+    insertAction("recover_"+string(ACTION_GET_PASS),
+                 static_cast<f_action>(&CubePicker::recoverPickPass));
 
     printActionDB();
 
@@ -152,7 +154,7 @@ bool CubePicker::pickARTag()
         }
         else
         {
-            cnt_ik_fail++;
+            ++cnt_ik_fail;
         }
 
         if (cnt_ik_fail == 10)

--- a/baxter_collaboration_lib/CMakeLists.txt
+++ b/baxter_collaboration_lib/CMakeLists.txt
@@ -148,6 +148,9 @@ if(CATKIN_ENABLE_TESTING)
                                  test/test_gripper.cpp)
   target_link_libraries(test_gripper robot_interface)
 
+  add_executable(gripper_keyboard test/gripper_keyboard.cpp)
+  target_link_libraries(gripper_keyboard robot_interface)
+
   ## Robot ROS thread image test
   add_rostest_gtest(test_ros_thread_image test/test_ros_thread_image.test
                                           test/test_ros_thread_image.cpp)

--- a/baxter_collaboration_lib/CMakeLists.txt
+++ b/baxter_collaboration_lib/CMakeLists.txt
@@ -149,7 +149,8 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_gripper robot_interface)
 
   add_executable(gripper_keyboard test/gripper_keyboard.cpp)
-  target_link_libraries(gripper_keyboard robot_interface)
+  target_link_libraries(gripper_keyboard ${catkin_LIBRARIES}
+                                         robot_interface)
 
   ## Robot ROS thread image test
   add_rostest_gtest(test_ros_thread_image test/test_ros_thread_image.test

--- a/baxter_collaboration_lib/CMakeLists.txt
+++ b/baxter_collaboration_lib/CMakeLists.txt
@@ -148,6 +148,7 @@ if(CATKIN_ENABLE_TESTING)
                                  test/test_gripper.cpp)
   target_link_libraries(test_gripper robot_interface)
 
+  ## Gripper Keyboard tests the grippers directly on the robot
   add_executable(gripper_keyboard test/gripper_keyboard.cpp)
   target_link_libraries(gripper_keyboard ${catkin_LIBRARIES}
                                          robot_interface)

--- a/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
+++ b/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
@@ -74,10 +74,7 @@ private:
      * Wrapper for Gripper:open so that it can fit the action_db
      * @return true/false if success/failure
      */
-    bool openImpl()
-    {
-        return open();
-    }
+    bool openImpl() { return open(); }
 
 protected:
 

--- a/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
+++ b/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
@@ -71,7 +71,9 @@ private:
     void InternalThreadEntry();
 
     /**
-     * Wrapper for Gripper:open so that it can fit the action_db
+     * Wrapper for Gripper:open() so that it can fit the action_db specifications
+     * in terms of function signature.
+     *
      * @return true/false if success/failure
      */
     bool openImpl() { return open(); }

--- a/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
+++ b/baxter_collaboration_lib/include/robot_interface/arm_ctrl.h
@@ -65,10 +65,19 @@ private:
     std::thread arm_thread; // internal thread functionality
 
     /**
-     * Provides basic functionalities for the object, such as a goHome and releaseObject.
+     * Provides basic functionalities for the object, such as a goHome and open.
      * For deeper, class-specific specialization, please modify doAction() instead.
      */
     void InternalThreadEntry();
+
+    /**
+     * Wrapper for Gripper:open so that it can fit the action_db
+     * @return true/false if success/failure
+     */
+    bool openImpl()
+    {
+        return open();
+    }
 
 protected:
 

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -30,8 +30,8 @@ private:
 
     std::string parameters; // parameters for the gripper
 
-    int       cmd_sequence;
-    std::string cmd_sender;
+    int       cmd_sequence; // counter that tracks the sequence of gripper commands
+    std::string cmd_sender; // retains the name of the node sending gripper commands
 
     /**
      * Callback that handles the gripper state messages.

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -18,10 +18,11 @@ private:
     bool   use_robot;       // Flag to know if we're going to use the robot or not
     bool   first_run;       // Flag to calibrate the gripper at startup if needed
 
-    ros::NodeHandle rnh;      // ROS node handle
-    ros::Subscriber sub;      // Subscriber to receive the state of the gripper
-    ros::Publisher  pub;      // Publisher for requesting actions to the gripper
-    ros::Subscriber sub_prop; // Subscriber to receive the properties of the gripper
+    ros::NodeHandle rnh;       // ROS node handle
+    ros::Subscriber sub;       // Subscriber to receive the state of the gripper
+    ros::Publisher  pub;       // Publisher for requesting actions to the gripper
+    ros::Subscriber sub_prop;  // Subscriber to receive the properties of the gripper
+    ros::AsyncSpinner spinner; // AsyncSpinner to handle callbacks
 
     baxter_core_msgs::EndEffectorState      state;      // State of the gripper
     baxter_core_msgs::EndEffectorProperties properties; // properties of the gripper

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -28,6 +28,8 @@ private:
     std::mutex mutex_state;                             // mutex for controlled state access
     std::mutex mutex_properties;                        // mutex for controlled properties access
 
+    std::string parameters; // parameters for the gripper
+
     int       cmd_sequence;
     std::string cmd_sender;
 
@@ -85,6 +87,18 @@ private:
     void command(std::string _cmd, bool _block=false,
                 double _timeout=0.0, std::string _args="");
 
+    /**
+     * Set the parameters that will describe the position command execution
+     * @param _parameters key-value pairs of parameters
+     * @param _defaults   to set or not set the parameters described in validParameters
+     */
+    void setParameters(std::string _parameters="", bool _defaults=true);
+
+    /**
+     * Returns dict of available gripper parameters with default parameters
+     * @return valid parameters as a string, but mimicking a Python/JSON dict
+     */
+    std::string validParameters();
 
     /**
      * Manage roll over with safe value

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -5,6 +5,7 @@
 
 #include <baxter_core_msgs/EndEffectorState.h>
 #include <baxter_core_msgs/EndEffectorCommand.h>
+#include <baxter_core_msgs/EndEffectorProperties.h>
 
 #include "robot_utils/utils.h"
 
@@ -16,12 +17,14 @@ private:
     bool   use_robot;       // Flag to know if we're going to use the robot or not
     bool   first_run;       // Flag to calibrate the gripper at startup if needed
 
-    ros::NodeHandle rnh;    // ROS node handle
-    ros::Subscriber sub;    // Subscriber to receive the state of the gripper
-    ros::Publisher  pub;    // Publisher for requesting actions to the gripper
+    ros::NodeHandle rnh;      // ROS node handle
+    ros::Subscriber sub;      // Subscriber to receive the state of the gripper
+    ros::Publisher  pub;      // Publisher for requesting actions to the gripper
+    ros::Subscriber sub_prop; // Subscriber to receive the properties of the gripper
 
-    std::mutex mutex;                          // mutex for controlled thread access
-    baxter_core_msgs::EndEffectorState state;  // State of the gripper
+    std::mutex mutex;                              // mutex for controlled thread access
+    baxter_core_msgs::EndEffectorState state;      // State of the gripper
+    baxter_core_msgs::EndEffectorProperties properties; // properties of the gripper
 
     /**
      * Callback that handles the gripper state messages.
@@ -72,6 +75,12 @@ public:
      */
     baxter_core_msgs::EndEffectorState getGripperState();
 
+    /**
+     * sets and gets the properties of the gripper, thread-safely
+     */
+    void setGripperProperties(const baxter_core_msgs::EndEffectorProperties& _properties);
+    baxter_core_msgs::EndEffectorProperties getGripperProperties();
+
     bool gripObject();
 
     bool releaseObject();
@@ -120,6 +129,8 @@ public:
 
     bool reboot();
     bool cmd_reboot();
+    std::string type();
+    void gripperCbProp(const baxter_core_msgs::EndEffectorProperties &msg);
 
     /**
      * Destructor

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -17,6 +17,7 @@ private:
 
     bool   use_robot;       // Flag to know if we're going to use the robot or not
     bool   first_run;       // Flag to calibrate the gripper at startup if needed
+    bool    prop_set;       // Flag to know if the properties were successfully set
 
     ros::NodeHandle rnh;       // ROS node handle
     ros::Subscriber sub;       // Subscriber to receive the state of the gripper
@@ -242,6 +243,12 @@ public:
      * Allows (and requires) new gripper calibration to be run.
      */
     void clearCalibration();
+
+    /**
+     * Power cycle the gripper, removing calibration information
+     * Basic call to the reboot command. Does not clear errors that could occur during boot
+     */
+    void reboot();
 
     /**
      * Destructor

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -22,8 +22,9 @@ private:
     ros::Publisher  pub;      // Publisher for requesting actions to the gripper
     ros::Subscriber sub_prop; // Subscriber to receive the properties of the gripper
 
-    std::mutex mutex;                                   // mutex for controlled thread access
+    std::mutex state_mutex;                             // mutex for controlled thread access
     baxter_core_msgs::EndEffectorState state;           // State of the gripper
+    std::mutex properties_mutex;
     baxter_core_msgs::EndEffectorProperties properties; // properties of the gripper
 
     /**
@@ -79,6 +80,11 @@ private:
      */
     void command(std::string _cmd, bool _block=false,
         double _timeout=0.0, std::string _args="");
+
+    /**
+     * Warns user about functions beyond the capability of a gripper type
+     */
+    void capability_warning(std::string _function);
 
     /** Legacy code */
     /**

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -22,9 +22,9 @@ private:
     ros::Publisher  pub;      // Publisher for requesting actions to the gripper
     ros::Subscriber sub_prop; // Subscriber to receive the properties of the gripper
 
-    std::mutex state_mutex;                             // mutex for controlled thread access
+    std::mutex mutex_state;                             // mutex for controlled thread access
     baxter_core_msgs::EndEffectorState state;           // State of the gripper
-    std::mutex properties_mutex;
+    std::mutex mutex_properties;
     baxter_core_msgs::EndEffectorProperties properties; // properties of the gripper
 
     /**
@@ -61,7 +61,7 @@ private:
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command success
      */
-    void command_suction(bool _block=false, double _timeout=5.0);
+    void commandSuction(bool _block=false, double _timeout=5.0);
 
     /**
      * Command the gripper position movement
@@ -69,7 +69,7 @@ private:
      * @param _block    is the command blocking or non-blocking
      * @param _timeout  timeout in seconds for command success
      */
-    void command_position(double _position, bool _block=false, double _timeout=5.0);
+    void commandPosition(double _position, bool _block=false, double _timeout=5.0);
 
     /**
      * Raw command call to directly control gripper
@@ -79,12 +79,12 @@ private:
      * @param _args    parameters and their values in JSON
      */
     void command(std::string _cmd, bool _block=false,
-        double _timeout=0.0, std::string _args="");
+                double _timeout=0.0, std::string _args="");
 
     /**
      * Warns user about functions beyond the capability of a gripper type
      */
-    void capability_warning(std::string _function);
+    void capabilityWarning(std::string _function);
 
     /** Legacy code */
     /**
@@ -120,9 +120,16 @@ public:
     baxter_core_msgs::EndEffectorState getGripperState();
 
     /**
-     * sets and gets the properties of the gripper, thread-safely
+     * Sets properties to the new properties, thread-safely
+     *
+     * @param _properties the new properties
      */
     void setGripperProperties(const baxter_core_msgs::EndEffectorProperties& _properties);
+
+    /**
+     * Gets the properties of the gripper, thread-safely
+     * @return the properties of the gripper
+     */
     baxter_core_msgs::EndEffectorProperties getGripperProperties();
 
     bool gripObject();

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -22,8 +22,8 @@ private:
     ros::Publisher  pub;      // Publisher for requesting actions to the gripper
     ros::Subscriber sub_prop; // Subscriber to receive the properties of the gripper
 
-    std::mutex mutex;                              // mutex for controlled thread access
-    baxter_core_msgs::EndEffectorState state;      // State of the gripper
+    std::mutex mutex;                                   // mutex for controlled thread access
+    baxter_core_msgs::EndEffectorState state;           // State of the gripper
     baxter_core_msgs::EndEffectorProperties properties; // properties of the gripper
 
     /**
@@ -34,7 +34,7 @@ private:
     /**
      * Callback that handles the gripper properties messages
      */
-    void gripperCbProp(const baxter_core_msgs::EndEffectorProperties &msg);
+    void gripperPropCb(const baxter_core_msgs::EndEffectorProperties &msg);
 
     /**
      * @brief Calibrates the gripper
@@ -47,6 +47,13 @@ private:
      * @return The ID of the gripper
      */
     int get_id();
+
+    /**
+     * Stop the gripper at the current position and apply the holding force
+     * @param _block   is the command blocking or non-blocking
+     * @param _timeout timeout in seconds for command success
+     */
+    void stop(bool _block=true, double _timeout=5.0);
 
     /**
      * Command the gripper suction
@@ -73,6 +80,7 @@ private:
     void command(std::string _cmd, bool _block=false,
         double _timeout=0.0, std::string _args="");
 
+    /** Legacy code */
     /**
      * Closes the gripper
      **/
@@ -115,8 +123,8 @@ public:
 
     /**
      * Commands minimum gripper position
-     * @param _block   is the command blocking or non-blocking [False]
-     * @param _timeout timeout in seconds for open command success [5.0]
+     * @param _block   is the command blocking or non-blocking
+     * @param _timeout timeout in seconds for open command success
      */
     void close(bool _block=false, double _timeout=5.0);
 
@@ -124,8 +132,8 @@ public:
 
     /**
      * Commands maximum gripper position
-     * @param _block   is the command blocking or non-blocking [False]
-     * @param _timeout timeout in seconds for open command success [5.0]
+     * @param _block   is the command blocking or non-blocking
+     * @param _timeout timeout in seconds for open command success
      */
     void open(bool _block=false, double _timeout=5.0);
 

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -41,9 +41,23 @@ private:
     void gripperCb(const baxter_core_msgs::EndEffectorState &msg);
 
     /**
+     * Sets the state to the new state, thread-safely
+     *
+     * @param _state the new state
+     */
+    void setGripperState(const baxter_core_msgs::EndEffectorState& _state);
+
+    /**
      * Callback that handles the gripper properties messages
      */
     void gripperPropCb(const baxter_core_msgs::EndEffectorProperties &msg);
+
+    /**
+     * Sets properties to the new properties, thread-safely
+     *
+     * @param _properties the new properties
+     */
+    void setGripperProperties(const baxter_core_msgs::EndEffectorProperties& _properties);
 
     /**
      * Gets the ID of the gripper
@@ -55,23 +69,26 @@ private:
      * Stop the gripper at the current position and apply the holding force
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command success
+     * @return true/false if success/failure
      */
-    void stop(bool _block=true, double _timeout=5.0);
+    bool stop(bool _block=true, double _timeout=5.0);
 
     /**
      * Command the gripper suction
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command success
+     * @return true/false if success/failure
      */
-    void commandSuction(bool _block=false, double _timeout=5.0);
+    bool commandSuction(bool _block=false, double _timeout=5.0);
 
     /**
      * Command the gripper position movement
      * @param _position in % 0=close, 100=open
      * @param _block    is the command blocking or non-blocking
      * @param _timeout  timeout in seconds for command success
+     * @return true/false if success/failure
      */
-    void commandPosition(double _position, bool _block=false, double _timeout=5.0);
+    bool commandPosition(double _position, bool _block=false, double _timeout=5.0);
 
     /**
      * Raw command call to directly control gripper
@@ -80,7 +97,7 @@ private:
      * @param _timeout timeout in seconds for command evaluation
      * @param _args    parameters and their values in JSON
      */
-    void command(std::string _cmd, bool _block=false,
+    bool command(std::string _cmd, bool _block=false,
                  double _timeout=0.0, std::string _args="");
 
     /**
@@ -113,18 +130,6 @@ private:
      */
     void wait(ros::Duration _timeout);
 
-    /** Legacy code */
-
-    /**
-     * Closes the gripper
-     **/
-    void suck();
-
-    /**
-     * Opens the gripper
-     **/
-    void blow();
-
 public:
     /**
      * Constructor of the class
@@ -135,24 +140,10 @@ public:
     explicit Gripper(std::string _limb, bool _use_robot = true);
 
     /**
-     * Sets the state to the new state, thread-safely
-     *
-     * @param _state the new state
-     */
-    void setGripperState(const baxter_core_msgs::EndEffectorState& _state);
-
-    /**
      * Gets the state of the gripper, thread-safely.
      * @return the state of the gripper
      */
     baxter_core_msgs::EndEffectorState getGripperState();
-
-    /**
-     * Sets properties to the new properties, thread-safely
-     *
-     * @param _properties the new properties
-     */
-    void setGripperProperties(const baxter_core_msgs::EndEffectorProperties& _properties);
 
     /**
      * Gets the properties of the gripper, thread-safely
@@ -162,17 +153,21 @@ public:
 
     /**
      * Commands minimum gripper position
+     *
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for open command success
+     * @return true/false if success/failure
      */
-    void close(bool _block=false, double _timeout=5.0);
+    bool close(bool _block=false, double _timeout=5.0);
 
     /**
      * Commands maximum gripper position
+     *
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for open command success
+     * @return true/false if success/failure
      */
-    void open(bool _block=false, double _timeout=5.0);
+    bool open(bool _block=false, double _timeout=5.0);
 
     /**
      * Returns a value indicating if the vacuum gripper is enable, so it can be operated.
@@ -228,15 +223,17 @@ public:
 
     /**
      * Returns the type of the gripper
-     * @return the type, "electric", "suction" or "custom"
+     * @return the type, "electric", "suction" or "uninitialized"
      */
     std::string type();
 
     /**
      * @brief Calibrates the gripper
      * @details It calibrates the gripper on startup if not already calibrated.
+     * @param _block   is the command blocking or non-blocking
+     * @param _timeout timeout in seconds for command evaluation
      */
-    void calibrate();
+    void calibrate(bool _block=false, double _timeout=0.0);
 
     /**
      * Clear calibration information from gripper.
@@ -245,10 +242,11 @@ public:
     void clearCalibration();
 
     /**
-     * Power cycle the gripper, removing calibration information
-     * Basic call to the reboot command. Does not clear errors that could occur during boot
+     * Power cycle the gripper, removing calibration information in a blocking manner
+     * Does not clear errors that could occur during boot
+     * @return true/false if success/failure
      */
-    void reboot();
+    bool reboot();
 
     /**
      * Destructor

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -44,6 +44,16 @@ private:
     int get_id();
 
     /**
+     * Raw command call to directly control gripper
+     * @param _cmd     string of known gripper commands
+     * @param _block   command is blocking or non-blocking
+     * @param _timeout timeout in seconds for command evaluation
+     * @param _args    parameters and their values in JSON
+     */
+    void command(std::string _cmd, bool _block=false,
+        double _timeout=0.0, std::string _args="");
+
+    /**
      * Closes the gripper
      **/
     void suck();

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -85,7 +85,7 @@ private:
      * @param _args    parameters and their values in JSON
      */
     void command(std::string _cmd, bool _block=false,
-                double _timeout=0.0, std::string _args="");
+                 double _timeout=0.0, std::string _args="");
 
     /**
      * Set the parameters that will describe the position command execution
@@ -110,6 +110,12 @@ private:
      * Warns user about functions beyond the capability of a gripper type
      */
     void capabilityWarning(std::string _function);
+
+    /**
+     * Waits until the timeout is complete
+     * @param _timeout the number of seconds to wait
+     */
+    void wait(ros::Duration _timeout);
 
     /** Legacy code */
     /**
@@ -212,6 +218,16 @@ public:
     bool is_gripping();
 
     /**
+     * Returns bool describing if the gripper is capable of force control
+     */
+    bool hasForce();
+
+    /**
+     * Returns bool describing if the gripper is capable of position control
+     */
+    bool hasPosition();
+
+    /**
      * Returns the limb the gripper belongs to
      * @return the limb, either "left" or "right"
      **/
@@ -222,9 +238,6 @@ public:
      * @return the type, "electric", "suction" or "custom"
      */
     std::string type();
-
-
-    void reboot();
 
     /**
      * Destructor

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -32,6 +32,11 @@ private:
     void gripperCb(const baxter_core_msgs::EndEffectorState &msg);
 
     /**
+     * Callback that handles the gripper properties messages
+     */
+    void gripperCbProp(const baxter_core_msgs::EndEffectorProperties &msg);
+
+    /**
      * @brief Calibrates the gripper
      * @details It calibrates the gripper on startup if not already calibrated.
      */
@@ -44,9 +49,24 @@ private:
     int get_id();
 
     /**
+     * Command the gripper suction
+     * @param _block   is the command blocking or non-blocking
+     * @param _timeout timeout in seconds for command success
+     */
+    void command_suction(bool _block=false, double _timeout=5.0);
+
+    /**
+     * Command the gripper position movement
+     * @param _position in % 0=close, 100=open
+     * @param _block    is the command blocking or non-blocking
+     * @param _timeout  timeout in seconds for command success
+     */
+    void command_position(double _position, bool _block=false, double _timeout=5.0);
+
+    /**
      * Raw command call to directly control gripper
      * @param _cmd     string of known gripper commands
-     * @param _block   command is blocking or non-blocking
+     * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command evaluation
      * @param _args    parameters and their values in JSON
      */
@@ -93,7 +113,21 @@ public:
 
     bool gripObject();
 
+    /**
+     * Commands minimum gripper position
+     * @param _block   is the command blocking or non-blocking [False]
+     * @param _timeout timeout in seconds for open command success [5.0]
+     */
+    void close(bool _block=false, double _timeout=5.0);
+
     bool releaseObject();
+
+    /**
+     * Commands maximum gripper position
+     * @param _block   is the command blocking or non-blocking [False]
+     * @param _timeout timeout in seconds for open command success [5.0]
+     */
+    void open(bool _block=false, double _timeout=5.0);
 
     /**
      * Returns a value indicating if the vacuum gripper is enable, so it can be operated.
@@ -137,9 +171,14 @@ public:
      **/
     std::string getGripperLimb()  { return limb; };
 
-    void reboot();
+    /**
+     * Returns the type of the gripper
+     * @return the type, "electric", "suction" or "custom"
+     */
     std::string type();
-    void gripperCbProp(const baxter_core_msgs::EndEffectorProperties &msg);
+
+
+    void reboot();
 
     /**
      * Destructor

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -13,21 +13,22 @@
 class Gripper
 {
 private:
-    std::string limb;       // Limb of the gripper: left or right
+    ros::NodeHandle rnh;    // ROS node handle
+    std::string    limb;    // Limb of the gripper: left or right
 
     bool   use_robot;       // Flag to know if we're going to use the robot or not
     bool   first_run;       // Flag to calibrate the gripper at startup if needed
     bool    prop_set;       // Flag to know if the properties were successfully set
 
-    ros::NodeHandle rnh;       // ROS node handle
-    ros::Subscriber sub;       // Subscriber to receive the state of the gripper
-    ros::Publisher  pub;       // Publisher for requesting actions to the gripper
-    ros::Subscriber sub_prop;  // Subscriber to receive the properties of the gripper
+    ros::Subscriber sub_state; // Subscriber to receive the state of the gripper
+    ros::Subscriber  sub_prop; // Subscriber to receive the properties of the gripper
+    ros::Publisher    pub_cmd; // Publisher for requesting actions to the gripper
+
     ros::AsyncSpinner spinner; // AsyncSpinner to handle callbacks
 
-    baxter_core_msgs::EndEffectorState      state;      // State of the gripper
+    baxter_core_msgs::EndEffectorState           state; // State of the gripper
     baxter_core_msgs::EndEffectorProperties properties; // properties of the gripper
-    std::mutex mutex_state;                             // mutex for controlled state access
+    std::mutex      mutex_state;                        // mutex for controlled state access
     std::mutex mutex_properties;                        // mutex for controlled properties access
 
     std::string parameters; // parameters for the gripper
@@ -61,12 +62,14 @@ private:
 
     /**
      * Gets the ID of the gripper
+     *
      * @return The ID of the gripper
      */
     int get_id();
 
     /**
      * Stop the gripper at the current position and apply the holding force
+     *
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command success
      * @return true/false if success/failure
@@ -75,6 +78,7 @@ private:
 
     /**
      * Command the gripper suction
+     *
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command success
      * @return true/false if success/failure
@@ -83,6 +87,7 @@ private:
 
     /**
      * Command the gripper position movement
+     *
      * @param _position in % 0=close, 100=open
      * @param _block    is the command blocking or non-blocking
      * @param _timeout  timeout in seconds for command success
@@ -92,16 +97,19 @@ private:
 
     /**
      * Raw command call to directly control gripper
+     *
      * @param _cmd     string of known gripper commands
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command evaluation
      * @param _args    parameters and their values in JSON
+     * @return true/false if success/failure
      */
     bool command(std::string _cmd, bool _block=false,
                  double _timeout=0.0, std::string _args="");
 
     /**
      * Set the parameters that will describe the position command execution
+     *
      * @param _parameters key-value pairs of parameters
      * @param _defaults   to set or not set the parameters described in validParameters
      */
@@ -109,12 +117,14 @@ private:
 
     /**
      * Returns dict of available gripper parameters with default parameters
+     *
      * @return valid parameters as a string, but mimicking a Python/JSON dict
      */
     std::string validParameters();
 
     /**
      * Manage roll over with safe value
+     *
      * @return cmd_sequence counter
      */
     int incCmdSeq();
@@ -126,9 +136,10 @@ private:
 
     /**
      * Waits until the timeout is complete
+     *
      * @param _timeout the number of seconds to wait
      */
-    void wait(ros::Duration _timeout);
+    bool wait(ros::Duration _timeout);
 
 public:
     /**
@@ -141,12 +152,14 @@ public:
 
     /**
      * Gets the state of the gripper, thread-safely.
+     *
      * @return the state of the gripper
      */
     baxter_core_msgs::EndEffectorState getGripperState();
 
     /**
      * Gets the properties of the gripper, thread-safely
+     *
      * @return the properties of the gripper
      */
     baxter_core_msgs::EndEffectorProperties getGripperProperties();
@@ -171,65 +184,73 @@ public:
 
     /**
      * Returns a value indicating if the vacuum gripper is enable, so it can be operated.
+     *
      * @return true/false if enabled or not.
      **/
     bool is_enabled();
 
     /**
      * Indicating if the gripper is calibrated.
+     *
      * @return True/false if calibrated or not.
      **/
     bool is_calibrated();
 
     /**
      * Returns a value indicating if the vacuum gripper is ready for gripping.
+     *
      * @return True if it is ready, false otherwise.
      **/
     bool is_ready_to_grip();
 
     /**
      * Returns a value indicating if the gripper is in error state.
+     *
      * @return True if the gripper is in error state, false otherwise.
      **/
     bool has_error();
 
     /**
      * Returns a value indicating if the vacuum gripper is sucking.
+     *
      * @return True if it is sucking, false otherwise.
      **/
     bool is_sucking();
 
     /**
      * Returns a value indicating if the gripper has something attached.
+     *
      * @return True if it is gripping an object, false otherwise.
      **/
     bool is_gripping();
 
     /**
-     * Returns bool describing if the gripper is capable of force control
+     * @return bool describing if the gripper is capable of force control
      */
     bool hasForce();
 
     /**
-     * Returns bool describing if the gripper is capable of position control
+     * @return bool describing if the gripper is capable of position control
      */
     bool hasPosition();
 
     /**
      * Returns the limb the gripper belongs to
+     *
      * @return the limb, either "left" or "right"
      **/
     std::string getGripperLimb()  { return limb; };
 
     /**
      * Returns the type of the gripper
+     *
      * @return the type, "electric", "suction" or "uninitialized"
      */
     std::string type();
 
     /**
-     * @brief Calibrates the gripper
-     * @details It calibrates the gripper on startup if not already calibrated.
+     * Calibrates the gripper on startup if not already calibrated.
+     *
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for command evaluation
      */
@@ -244,6 +265,7 @@ public:
     /**
      * Power cycle the gripper, removing calibration information in a blocking manner
      * Does not clear errors that could occur during boot
+     *
      * @return true/false if success/failure
      */
     bool reboot();
@@ -252,12 +274,6 @@ public:
      * Destructor
      */
     ~Gripper();
-
-    /** Legacy code */
-
-    bool gripObject(); // would recommend using close() instead
-
-    bool releaseObject(); // would recommend using open() instead
 };
 
 #endif // __GRIPPER_H__

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -2,6 +2,7 @@
 #define __GRIPPER_H__
 
 #include <mutex>
+#include <limits>
 
 #include <baxter_core_msgs/EndEffectorState.h>
 #include <baxter_core_msgs/EndEffectorCommand.h>
@@ -22,10 +23,13 @@ private:
     ros::Publisher  pub;      // Publisher for requesting actions to the gripper
     ros::Subscriber sub_prop; // Subscriber to receive the properties of the gripper
 
-    std::mutex mutex_state;                             // mutex for controlled thread access
-    baxter_core_msgs::EndEffectorState state;           // State of the gripper
-    std::mutex mutex_properties;
+    baxter_core_msgs::EndEffectorState      state;      // State of the gripper
     baxter_core_msgs::EndEffectorProperties properties; // properties of the gripper
+    std::mutex mutex_state;                             // mutex for controlled state access
+    std::mutex mutex_properties;                        // mutex for controlled properties access
+
+    int       cmd_sequence;
+    std::string cmd_sender;
 
     /**
      * Callback that handles the gripper state messages.
@@ -80,6 +84,13 @@ private:
      */
     void command(std::string _cmd, bool _block=false,
                 double _timeout=0.0, std::string _args="");
+
+
+    /**
+     * Manage roll over with safe value
+     * @return cmd_sequence counter
+     */
+    int incCmdSeq();
 
     /**
      * Warns user about functions beyond the capability of a gripper type

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -127,8 +127,7 @@ public:
      **/
     std::string getGripperLimb()  { return limb; };
 
-    bool reboot();
-    bool cmd_reboot();
+    void reboot();
     std::string type();
     void gripperCbProp(const baxter_core_msgs::EndEffectorProperties &msg);
 

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -57,7 +57,7 @@ public:
      * @param      _limb either left or right
      * @param _use_robot if to use the robot or not
      **/
-    Gripper(std::string _limb, bool _use_robot = true);
+    explicit Gripper(std::string _limb, bool _use_robot = true);
 
     /**
      * Sets the state to the new state, thread-safely

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -44,12 +44,6 @@ private:
     void gripperPropCb(const baxter_core_msgs::EndEffectorProperties &msg);
 
     /**
-     * @brief Calibrates the gripper
-     * @details It calibrates the gripper on startup if not already calibrated.
-     */
-    void calibrate();
-
-    /**
      * Gets the ID of the gripper
      * @return The ID of the gripper
      */
@@ -118,6 +112,7 @@ private:
     void wait(ros::Duration _timeout);
 
     /** Legacy code */
+
     /**
      * Closes the gripper
      **/
@@ -163,16 +158,12 @@ public:
      */
     baxter_core_msgs::EndEffectorProperties getGripperProperties();
 
-    bool gripObject();
-
     /**
      * Commands minimum gripper position
      * @param _block   is the command blocking or non-blocking
      * @param _timeout timeout in seconds for open command success
      */
     void close(bool _block=false, double _timeout=5.0);
-
-    bool releaseObject();
 
     /**
      * Commands maximum gripper position
@@ -240,9 +231,27 @@ public:
     std::string type();
 
     /**
+     * @brief Calibrates the gripper
+     * @details It calibrates the gripper on startup if not already calibrated.
+     */
+    void calibrate();
+
+    /**
+     * Clear calibration information from gripper.
+     * Allows (and requires) new gripper calibration to be run.
+     */
+    void clearCalibration();
+
+    /**
      * Destructor
      */
     ~Gripper();
+
+    /** Legacy code */
+
+    bool gripObject(); // would recommend using close() instead
+
+    bool releaseObject(); // would recommend using open() instead
 };
 
 #endif // __GRIPPER_H__

--- a/baxter_collaboration_lib/include/robot_interface/gripper.h
+++ b/baxter_collaboration_lib/include/robot_interface/gripper.h
@@ -118,6 +118,9 @@ public:
      **/
     std::string getGripperLimb()  { return limb; };
 
+    bool reboot();
+    bool cmd_reboot();
+
     /**
      * Destructor
      */

--- a/baxter_collaboration_lib/include/robot_interface/robot_interface.h
+++ b/baxter_collaboration_lib/include/robot_interface/robot_interface.h
@@ -42,7 +42,7 @@ private:
 
     State         state;       // State of the controller
 
-    ros::AsyncSpinner spinner;  // AsyncSpinner to handle callbacks
+    ros::AsyncSpinner spinner; // AsyncSpinner to handle callbacks
 
     bool      use_robot;       // Flag to know if we're going to use the robot or not
     bool     use_forces;       // Flag to know if we're going to use the force feedback

--- a/baxter_collaboration_lib/include/robot_perception/cartesian_estimator.h
+++ b/baxter_collaboration_lib/include/robot_perception/cartesian_estimator.h
@@ -48,7 +48,7 @@ public:
     geometry_msgs::Pose pose;
 
     /* CONSTRUCTOR */
-    SegmentedObj(std::vector<double> _size);
+    explicit SegmentedObj(std::vector<double> _size);
     SegmentedObj(std::string _name, std::vector<double> _size, int _area_thres);
 
     /* DESTRUCTOR */
@@ -131,6 +131,7 @@ public:
      * Converts the segmented object to a string.
      * @return the segmented object as a string
      */
+    /* implicit */
     virtual operator std::string();
 
     /* GETTERS */
@@ -338,9 +339,10 @@ protected:
 
 public:
     /* CONSTRUCTORS */
-    CartesianEstimator(std::string _name);
+    explicit CartesianEstimator(std::string _name);
     CartesianEstimator(std::string _name,
-                       std::vector<std::string> _objs_name, cv::Mat _objs_size);
+                       std::vector<std::string> _objs_name,
+                       cv::Mat _objs_size);
 
     /* DESTRUCTOR */
     ~CartesianEstimator();

--- a/baxter_collaboration_lib/include/robot_perception/cartesian_estimator_hsv.h
+++ b/baxter_collaboration_lib/include/robot_perception/cartesian_estimator_hsv.h
@@ -43,6 +43,7 @@ public:
      * Converts the segmented object to a string.
      * @return the segmented object as a string
      */
+    /* implicit */
     operator std::string();
 };
 
@@ -98,7 +99,7 @@ protected:
 
 public:
     /* CONSTRUCTORS */
-    CartesianEstimatorHSV(std::string  _name);
+    explicit CartesianEstimatorHSV(std::string  _name);
 
     ~CartesianEstimatorHSV();
 };

--- a/baxter_collaboration_lib/include/robot_perception/hsv_detection.h
+++ b/baxter_collaboration_lib/include/robot_perception/hsv_detection.h
@@ -21,7 +21,7 @@ struct colorRange
      *
      * @param  _cR the TypeArray read from the parameter server.
      */
-    colorRange(XmlRpc::XmlRpcValue _cR);
+    explicit colorRange(XmlRpc::XmlRpcValue _cR);
 
     /**
     * Copy Operator
@@ -62,7 +62,7 @@ struct hsvColorRange
      *
      * @param  _param the XmlRpcValue read from the parameter server.
      */
-    hsvColorRange(XmlRpc::XmlRpcValue _params);
+    explicit hsvColorRange(XmlRpc::XmlRpcValue _params);
 
     cv::Scalar get_hsv_min() { return cv::Scalar(H.min, S.min, V.min); };
     cv::Scalar get_hsv_max() { return cv::Scalar(H.max, S.max, V.max); };

--- a/baxter_collaboration_lib/include/robot_utils/baxter_trac_ik.h
+++ b/baxter_collaboration_lib/include/robot_utils/baxter_trac_ik.h
@@ -1,3 +1,6 @@
+#ifndef __BAXTER_TRAC_IK_H__
+#define __BAXTER_TRAC_IK_H__
+
 #include <trac_ik/trac_ik.hpp>
 #include <ros/ros.h>
 #include <kdl/chainiksolverpos_nr_jl.hpp>
@@ -19,7 +22,7 @@ private:
     KDL::JntArray *_nominal;
 
 public:
-    baxterTracIK(std::string limb, bool _use_robot = true);
+    explicit baxterTracIK(std::string limb, bool _use_robot = true);
 
     ~baxterTracIK();
 
@@ -33,3 +36,4 @@ public:
     void computeFwdKin(KDL::JntArray jointpositions);
 };
 
+#endif

--- a/baxter_collaboration_lib/include/robot_utils/ros_thread_image.h
+++ b/baxter_collaboration_lib/include/robot_utils/ros_thread_image.h
@@ -56,7 +56,7 @@ public:
      * @param _name     name of the object
      * @param _encoding encoding for the image
      */
-    ROSThreadImage(std::string _name, std::string _encoding = "bgr8");
+    explicit ROSThreadImage(std::string _name, std::string _encoding = "bgr8");
 
     /**
      * Destructor

--- a/baxter_collaboration_lib/include/robot_utils/utils.h
+++ b/baxter_collaboration_lib/include/robot_utils/utils.h
@@ -283,7 +283,7 @@ public:
      *
      * @param _state the new state
      */
-    State(int _state = START) : state(_state) { };
+    explicit State(int _state = START) : state(_state) { };
 
     /**
      * Sets the state to a new state. Updates the time accordingly.
@@ -295,11 +295,13 @@ public:
     /**
      * Returns the state as an integer
      */
+    /* implicit */
     operator int();
 
     /**
      * Returns the state as a std::string (i.e. a text description of the state)
      */
+    /* implicit */
     operator std::string();
 };
 

--- a/baxter_collaboration_lib/src/robot_interface/arm_ctrl.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/arm_ctrl.cpp
@@ -19,7 +19,7 @@ ArmCtrl::ArmCtrl(string _name, string _limb, bool _use_robot, bool _use_forces, 
     ROS_INFO("[%s] Created service server with name  : %s", getLimb().c_str(), topic.c_str());
 
     insertAction(ACTION_HOME,    &ArmCtrl::goHome);
-    insertAction(ACTION_RELEASE, &ArmCtrl::releaseObject);
+    insertAction(ACTION_RELEASE, &ArmCtrl::openImpl);
 
     nh.param<bool>("internal_recovery",  internal_recovery, true);
     ROS_INFO("[%s] Internal_recovery flag set to %s", getLimb().c_str(),
@@ -585,7 +585,7 @@ void ArmCtrl::setHomeConfiguration(std::string _loc)
 bool ArmCtrl::goHome()
 {
     bool res = homePoseStrict();
-    releaseObject();
+    open();
     return res;
 }
 

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -226,7 +226,7 @@ void Gripper::open(bool _block, double _timeout)
 {
     if(type() == "electric")
     {
-        command_position(100.0, _block, _timeout);
+        command_position(95.0, _block, _timeout);
     }
     else if (type() == "suction")
     {
@@ -243,7 +243,7 @@ void Gripper::close(bool _block, double _timeout)
 {
     if(type() == "electric")
     {
-        command_position(0.0, _block, _timeout);
+        command_position(5.0, _block, _timeout);
     }
     else if (type() == "suction")
     {
@@ -262,11 +262,11 @@ void Gripper::command_position(double _position, bool _block, double _timeout)
     {
         ROS_WARN("Gripper is not an electric type");
     }
-    if(_position > 100.0 || _position < 0.0)
+    if(_position >= 0.0 && _position <= 100.0)
     {
         std::string position_cmd = EndEffectorCommand::CMD_GO;
         std::string position_args =
-            "{\"position\": " + std::to_string(_position);
+            "{\"position\": " + std::to_string(_position) + "}";
         command(position_cmd, _block, _timeout, position_args);
     }
     else
@@ -282,8 +282,10 @@ void Gripper::command_suction(bool _block, double _timeout)
         ROS_WARN("Gripper is not a suction type");
     }
     std::string suction_cmd = EndEffectorCommand::CMD_GO;
+    cout << std::to_string(_timeout) << endl;
     std::string suction_args =
-        "{\"grip_attempt_seconds\": " + std::to_string(_timeout); // default timeout=5.0
+        "{\"grip_attempt_seconds\": " + std::to_string(_timeout) + "}";// default timeout=5.0
+    cout << suction_args << endl;
     command(suction_cmd, _block, _timeout, suction_args);
 }
 

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -96,8 +96,6 @@ void Gripper::gripperPropCb(const EndEffectorProperties &msg)
 {
     setGripperProperties(msg);
     prop_set = true;
-    ROS_INFO("Properties updated");
-    ROS_INFO("%i", properties.ui_type);
 
     // shut down the subscriber after the properties are set once
     // because these properties do not change
@@ -230,7 +228,7 @@ bool Gripper::open(bool _block, double _timeout)
 {
     if(type() == "electric")
     {
-        commandPosition(100.0, _block, _timeout);
+        return commandPosition(100.0, _block, _timeout);
     }
     else if (type() == "suction")
     {
@@ -243,7 +241,7 @@ bool Gripper::open(bool _block, double _timeout)
             return false;
         }
 
-        stop(_block, _timeout);
+        return stop(_block, _timeout);
     }
     else
     {
@@ -251,20 +249,18 @@ bool Gripper::open(bool _block, double _timeout)
         capabilityWarning("open");
         return false;
     }
-
-    return true;
 }
 
 bool Gripper::close(bool _block, double _timeout)
 {
     if(type() == "electric")
     {
-        commandPosition(0.0, _block, _timeout);
+        return commandPosition(0.0, _block, _timeout);
     }
     else if (type() == "suction")
     {
         // no checks here for is_sucking() so that the suction time may be extended as necessary
-        commandSuction(_block, _timeout);
+        return commandSuction(_block, _timeout);
     }
     else
     {
@@ -272,8 +268,6 @@ bool Gripper::close(bool _block, double _timeout)
         capabilityWarning("close");
         return false;
     }
-
-    return true;
 }
 
 bool Gripper::commandPosition(double _position, bool _block, double _timeout)
@@ -301,9 +295,7 @@ bool Gripper::commandPosition(double _position, bool _block, double _timeout)
         std::string position_args = "{\"position\": " +
                                      std::to_string(_position) + "}";
 
-        command(position_cmd, _block, _timeout, position_args);
-
-        return true;
+        return command(position_cmd, _block, _timeout, position_args);
     }
     else
     {
@@ -326,9 +318,7 @@ bool Gripper::commandSuction(bool _block, double _timeout)
     std::string suction_args = "{\"grip_attempt_seconds\": " +
                                 std::to_string(_timeout) + "}";
 
-    command(suction_cmd, _block, _timeout, suction_args);
-
-    return true;
+    return command(suction_cmd, _block, _timeout, suction_args);
 }
 
 bool Gripper::stop(bool _block, double _timeout)

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -12,9 +12,15 @@ Gripper::Gripper(std::string _limb, bool _use_robot) :
 {
     if (not use_robot) return;
 
+    // create a publisher for the gripper's commands
     pub = rnh.advertise<EndEffectorCommand>(
                    "/robot/end_effector/" + _limb + "_gripper/command", 1);
 
+    // create a subscriber to the gripper's properties
+    sub_prop = rnh.subscribe("/robot/end_effector/" + _limb + "_gripper/properties",
+                                SUBSCRIBER_BUFFER, &Gripper::gripperPropCb, this);
+
+    // create a subscriber to the gripper's state
     sub = rnh.subscribe("/robot/end_effector/" + _limb + "_gripper/state",
                            SUBSCRIBER_BUFFER, &Gripper::gripperCb, this);
 
@@ -29,10 +35,6 @@ Gripper::Gripper(std::string _limb, bool _use_robot) :
     init_state.moving     = EndEffectorState::STATE_UNKNOWN;
 
     setGripperState(init_state);
-
-    // create a subscriber to the gripper's properties
-    sub_prop = rnh.subscribe("/robot/end_effector/" + _limb + "_gripper/properties",
-                                SUBSCRIBER_BUFFER, &Gripper::gripperPropCb, this);
 
     spinner.start();
 

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -135,6 +135,11 @@ void Gripper::calibrate()
 
 void Gripper::suck()
 {
+    if(type() != "suction")
+    {
+        ROS_INFO("warning: this is not a suction gripper");
+    }
+
     EndEffectorCommand cmd;
     cmd.id=get_id();
     cmd.command=EndEffectorCommand::CMD_GRIP;
@@ -192,14 +197,13 @@ bool Gripper::is_gripping()
 
 // sarim's edits:
 
-bool Gripper::reboot()
+void Gripper::reboot()
 {
-    return true;
-}
-
-bool Gripper::cmd_reboot()
-{
-    return true;
+    EndEffectorCommand reboot;
+    reboot.id=get_id();
+    reboot.command=EndEffectorCommand::CMD_REBOOT;
+    pub.publish(reboot);
+    sleep(1.0);
 }
 
 std::string Gripper::type()

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -96,6 +96,8 @@ void Gripper::gripperPropCb(const EndEffectorProperties &msg)
 {
     setGripperProperties(msg);
     prop_set = true;
+    ROS_INFO("Properties updated");
+    ROS_INFO("%i", properties.ui_type);
 
     // shut down the subscriber after the properties are set once
     // because these properties do not change

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -7,8 +7,8 @@ using namespace baxter_core_msgs;
 using namespace std;
 
 Gripper::Gripper(std::string _limb, bool _use_robot) :
-                 limb(_limb), use_robot(_use_robot), first_run(true), cmd_sequence(0),
-                 cmd_sender(ros::this_node::getName())
+                 limb(_limb), use_robot(_use_robot), first_run(true), rnh(_limb),
+                 spinner(1), cmd_sequence(0), cmd_sender(ros::this_node::getName())
 {
     if (not use_robot) return;
 
@@ -34,8 +34,11 @@ Gripper::Gripper(std::string _limb, bool _use_robot) :
     sub_prop = rnh.subscribe("/robot/end_effector/" + _limb + "_gripper/properties",
                                 SUBSCRIBER_BUFFER, &Gripper::gripperPropCb, this);
 
+    spinner.start();
+
     // sleep to wait for the publisher to be ready
     ros::Duration(0.5).sleep();
+
     // set the gripper parameters to their defaults
     setParameters("", true);
 }

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -206,6 +206,24 @@ void Gripper::reboot()
     sleep(1.0);
 }
 
+void Gripper::command(std::string _cmd, bool _block,
+    double _timeout, std::string _args)
+{
+    EndEffectorCommand ee_cmd;
+    ee_cmd.id = get_id();
+    ee_cmd.command = _cmd;
+    ee_cmd.args = "";
+    if(_args != "")
+    {
+        ee_cmd.args = _args;
+    }
+    pub.publish(ee_cmd);
+    if(_block == true)
+    {
+        sleep(_timeout);
+    }
+}
+
 std::string Gripper::type()
 {
     int ui_code = getGripperProperties().ui_type;

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -335,7 +335,7 @@ std::string Gripper::type()
     }
     else
     {
-        return "undefined";
+        return "uninitialized";
     }
 }
 

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -177,7 +177,6 @@ void Gripper::close(bool _block, double _timeout)
     }
     else if (type() == "suction")
     {
-        // default block=False, default timeout=5.0
         command_suction(_block, _timeout);
     }
     else
@@ -212,7 +211,6 @@ void Gripper::command_suction(bool _block, double _timeout)
         ROS_WARN("Gripper is not a suction type");
     }
     std::string suction_cmd = EndEffectorCommand::CMD_GO;
-    cout << std::to_string(_timeout) << endl;
     std::string suction_args =
         "{\"grip_attempt_seconds\": " + std::to_string(_timeout) + "}";// default timeout=5.0
     cout << suction_args << endl;

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -32,8 +32,6 @@ Gripper::Gripper(std::string _limb, bool _use_robot) :
     // since the properties are fixed ,the callback is unsubscribed immediately afterwards
     sub_prop = rnh.subscribe("/robot/end_effector/" + _limb + "_gripper/properties",
                                 SUBSCRIBER_BUFFER, &Gripper::gripperCbProp, this);
-    sub_prop.shutdown();
-
 }
 
 void Gripper::setGripperState(const baxter_core_msgs::EndEffectorState& _state)
@@ -226,7 +224,7 @@ void Gripper::command(std::string _cmd, bool _block,
 
 std::string Gripper::type()
 {
-    int ui_code = getGripperProperties().ui_type;
+    int ui_code = (int) getGripperProperties().ui_type;
     if(ui_code == 1)
     {
         return "suction";

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -329,15 +329,6 @@ bool Gripper::stop(bool _block, double _timeout)
 
     if(type() == "electric")
     {
-        // calibrate the electric gripper if needed
-        // do it in a blocking manner so that the gripper does not move before calibration
-        if(not is_calibrated())
-        {
-            ROS_INFO("Calibrating gripper. Please wait...");
-            calibrate(true, 2.0);
-            ROS_INFO("Calibration complete");
-        }
-
         stop_cmd = EndEffectorCommand::CMD_STOP;
     }
     else if(type() == "suction")
@@ -351,9 +342,7 @@ bool Gripper::stop(bool _block, double _timeout)
         return false;
     }
 
-    command(stop_cmd, _block, _timeout);
-
-    return true;
+    return command(stop_cmd, _block, _timeout);
 }
 
 bool Gripper::command(std::string _cmd, bool _block,

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -28,8 +28,12 @@ Gripper::Gripper(std::string _limb, bool _use_robot) :
 
     setGripperState(init_state);
 
+    // create a subscriber to the gripper's properties
+    // since the properties are fixed ,the callback is unsubscribed immediately afterwards
     sub_prop = rnh.subscribe("/robot/end_effector/" + _limb + "_gripper/properties",
                                 SUBSCRIBER_BUFFER, &Gripper::gripperCbProp, this);
+    sub_prop.shutdown();
+
 }
 
 void Gripper::setGripperState(const baxter_core_msgs::EndEffectorState& _state)

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -340,11 +340,7 @@ std::string Gripper::type()
     }
     else
     {
-<<<<<<< HEAD
-        return "custom";
-=======
         return "uninitialized";
->>>>>>> b7d040fb60276c16716c4081a7e06796516c2e26
     }
 }
 

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -8,7 +8,7 @@ using namespace std;
 
 Gripper::Gripper(std::string _limb, bool _use_robot) :
                  rnh(_limb), limb(_limb), use_robot(_use_robot), first_run(true), prop_set(false),
-                 spinner(1), cmd_sequence(0), cmd_sender(ros::this_node::getName())
+                 spinner(4), cmd_sequence(0), cmd_sender(ros::this_node::getName())
 {
     if (not use_robot) return;
 
@@ -71,6 +71,7 @@ baxter_core_msgs::EndEffectorProperties Gripper::getGripperProperties()
 
 void Gripper::gripperCb(const EndEffectorState &msg)
 {
+    ROS_DEBUG("[%s_gripper] Received new state", getGripperLimb().c_str());
     setGripperState(msg);
 
     if (first_run)
@@ -94,6 +95,7 @@ void Gripper::gripperCb(const EndEffectorState &msg)
 
 void Gripper::gripperPropCb(const EndEffectorProperties &msg)
 {
+    ROS_DEBUG("[%s_gripper] Received gripper properties", getGripperLimb().c_str());
     setGripperProperties(msg);
     prop_set = true;
 
@@ -360,6 +362,7 @@ bool Gripper::command(std::string _cmd, bool _block,
         ee_cmd.args = _args;
     }
 
+    ROS_DEBUG("[%s_gripper] Publishing: %s", getGripperLimb().c_str(), _cmd.c_str());
     pub_cmd.publish(ee_cmd);
 
     if(_block)

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -286,13 +286,14 @@ bool Gripper::commandPosition(double _position, bool _block, double _timeout)
     if(not is_calibrated())
     {
         ROS_INFO("Calibrating gripper. Please wait...");
-        calibrate(true, 2.0);
+        calibrate(true, 3.0);
         ROS_INFO("Calibration complete");
     }
 
     // ensures that the gripper is positioned within physical limits
     if(_position >= 0.0 && _position <= 100.0)
     {
+        ROS_DEBUG("Commanding position %g", _position);
         std::string position_cmd = EndEffectorCommand::CMD_GO;
         std::string position_args = "{\"position\": " +
                                      std::to_string(_position) + "}";
@@ -364,7 +365,7 @@ bool Gripper::command(std::string _cmd, bool _block,
     if(_block)
     {
         ros::Duration timeout(_timeout);
-        wait(timeout);
+        return wait(timeout);
     }
 
     return true;
@@ -410,6 +411,7 @@ bool Gripper::wait(ros::Duration _timeout)
 
     while(ros::ok())
     {
+        ROS_DEBUG("Waiting...");
         if (ros::Time::now() - start > _timeout) { return true; };
 
         r.sleep();

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -156,6 +156,20 @@ bool Gripper::is_gripping()
     // return getGripperState().gripping==EndEffectorState::STATE_TRUE;
 }
 
+// sarim's edits:
+
+bool Gripper::reboot()
+{
+    return true;
+}
+
+bool Gripper::cmd_reboot()
+{
+    return true;
+}
+
+
+
 Gripper::~Gripper()
 {
 

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -343,10 +343,12 @@ void Gripper::wait(ros::Duration _timeout)
 {
     // waits until the difference between the start and
     // current time catches up to the timeout
+    ros::Rate r(100);
     ros::Time start = ros::Time::now();
-    while(ros::Time::now() - start < _timeout)
+    while(ros::ok() && ros::Time::now() - start < _timeout)
     {
         ros::spinOnce();
+        r.sleep();
     }
 }
 

--- a/baxter_collaboration_lib/src/robot_interface/gripper.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/gripper.cpp
@@ -335,7 +335,7 @@ std::string Gripper::type()
     }
     else
     {
-        return "custom";
+        return "undefined";
     }
 }
 

--- a/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
+++ b/baxter_collaboration_lib/src/robot_interface/robot_interface.cpp
@@ -606,7 +606,7 @@ bool RobotInterface::goToJointConfNoCheck(vector<double> joint_values)
 
     setJointNames(joint_cmd);
 
-    for (size_t i = 0; i < joint_values.size(); i++)
+    for (size_t i = 0; i < joint_values.size(); ++i)
     {
         joint_cmd.command.push_back(joint_values[i]);
     }

--- a/baxter_collaboration_lib/src/robot_perception/cartesian_estimator.cpp
+++ b/baxter_collaboration_lib/src/robot_perception/cartesian_estimator.cpp
@@ -26,7 +26,7 @@ void SegmentedObj::init()
     Rvec.create(3,1,CV_32FC1);
     Tvec.create(3,1,CV_32FC1);
 
-    for (int i=0;i<3;i++)
+    for (int i=0; i<3; ++i)
     {
         Tvec.at<float>(i,0)=Rvec.at<float>(i,0)=-999999;
     }
@@ -51,7 +51,7 @@ bool SegmentedObj::drawBox(cv::Mat &_img)
         cv::Point2f rect_points[4];
         rect.points(rect_points);
 
-        for( int j = 0; j < 4; j++ )
+        for( int j = 0; j < 4; ++j )
         {
             cv::line   (_img, rect_points[j], rect_points[(j+1)%4], color, 2, 8 );
             // cv::putText(_img, toString(j), rect_points[j],
@@ -177,7 +177,7 @@ bool CartesianEstimator::publishObjects()
     objects_msg.objects.clear();
     objects_msg.objects.resize(getNumValidObjects());
     objects_msg.header.stamp = curr_stamp;
-    objects_msg.header.seq++;
+    ++objects_msg.header.seq;
 
     int cnt = 0;
     for(size_t i = 0; i < objs.size(); ++i)
@@ -393,7 +393,7 @@ bool CartesianEstimator::poseCameraRF(int idx)
     cv::Point2f obj_segm_pts[4];
     objs[idx]->rect.points(obj_segm_pts);
 
-    for (int j=0; j<4; j++)
+    for (int j=0; j<4; ++j)
     {
         ImgPoints.at<float>(j,0)=obj_segm_pts[j].x;
         ImgPoints.at<float>(j,1)=obj_segm_pts[j].y;
@@ -526,7 +526,7 @@ int CartesianEstimator::getNumValidObjects()
     {
         if (objs[i])
         {
-            if (objs[i]->isThere())     res++;
+            if (objs[i]->isThere()) { ++res; }
         }
     }
 

--- a/baxter_collaboration_lib/src/robot_perception/cartesian_estimator_hsv.cpp
+++ b/baxter_collaboration_lib/src/robot_perception/cartesian_estimator_hsv.cpp
@@ -38,16 +38,16 @@ bool SegmentedObjHSV::detectObject(const cv::Mat& _in, cv::Mat& _out, cv::Mat& _
     cv::Mat img_thres = hsvThreshold(img_hsv, col);
 
     // Some morphological operations to remove noise and clean up the image
-    for (int i = 0; i < 2; ++i) erode(img_thres, img_thres, cv::Mat());
+    for (int i = 0; i < 2; ++i)  erode(img_thres, img_thres, cv::Mat());
     for (int i = 0; i < 4; ++i) dilate(img_thres, img_thres, cv::Mat());
-    for (int i = 0; i < 2; ++i) erode(img_thres, img_thres, cv::Mat());
+    for (int i = 0; i < 2; ++i)  erode(img_thres, img_thres, cv::Mat());
 
     // Find contours
     cv::findContours(img_thres, contours, hierarchy, CV_RETR_TREE,
                      CV_CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
 
     // Let's filter out contours that are too small to be an object
-    for( size_t i = 0; i < contours.size(); i++ )
+    for(size_t i = 0; i < contours.size(); ++i)
     {
         // ROS_INFO("IDX %lu Col %s Contour area %g", i, col.toString().c_str(),
         //                                            contourArea(contours[i], false));
@@ -82,7 +82,7 @@ bool SegmentedObjHSV::detectObject(const cv::Mat& _in, cv::Mat& _out, cv::Mat& _
         // int largest_area=0;
         // int largest_contour_idx=-1;
 
-        // for( size_t i = 0; i< filt_contours.size(); i++ )
+        // for(size_t i = 0; i< filt_contours.size(); ++i)
         // {
         //     double a = contourArea(filt_contours[i], false);  //  Find the area of contour
 

--- a/baxter_collaboration_lib/src/robot_utils/baxter_trac_ik.cpp
+++ b/baxter_collaboration_lib/src/robot_utils/baxter_trac_ik.cpp
@@ -54,7 +54,7 @@ baxterTracIK::baxterTracIK(std::string limb, bool _use_robot) :
     // Create Nominal chain configuration midway between all joint limits
     _nominal = new KDL::JntArray(_chain.getNrOfJoints());
 
-    for (int j=0; j < _nominal->data.size(); j++)
+    for (int j=0; j < _nominal->data.size(); ++j)
     {
       _nominal->operator()(j) = (ll(j)+ul(j))/2.0;
     }

--- a/baxter_collaboration_lib/src/robot_utils/utils.cpp
+++ b/baxter_collaboration_lib/src/robot_utils/utils.cpp
@@ -73,7 +73,7 @@ string toString(vector<double> const& _v)
 {
 	string res = "";
 
-	for(int i = 0, size = _v.size(); i < size; i++)
+	for(int i = 0, size = _v.size(); i < size; ++i)
 	{
 		res = res + toString(_v[i]) + ", ";
 	}

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -24,8 +24,9 @@ private:
     {
         char ch;
 
-        // continues while the ROS is running and the proceed flag is true
-        while(ros::ok() && proceed)
+        // continues while the proceed flag is true. The ros::ok() event
+        // will be catched only by the main thread.
+        while(proceed)
         {
             cin.get(ch);
             cin.ignore();

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -7,20 +7,24 @@ class GripperKeyboard
 {
 private:
 
-    bool           proceed;
-    char               key;
-    bool           set_key;
+    bool           proceed; // flag to continue or exit the main and internal threads
+    char               key; // storage for the user key press
+    bool           set_key; // flag to notify the main thread that a key has been stored
 
-    Gripper left_gripper;
-    Gripper right_gripper;
+    Gripper   left_gripper;
+    Gripper  right_gripper;
 
-    std::mutex mtx_set_key;
-    std::thread key_thread;
+    std::mutex mtx_set_key; // mutex to protect set_key
+    std::thread key_thread; // std::thread to run the thread function
 
-    void threadFunction()
+    /**
+     * Prompts the user for a key press and stores it for use by the main thread
+     */
+    void keyListener()
     {
         char ch;
 
+        // continues while the ROS is running and the proceed flag is true
         while(ros::ok() && proceed)
         {
             cin.get(ch);
@@ -42,16 +46,26 @@ private:
         return;
     }
 
+    /**
+     * Starts the internal thread
+     */
     void startThread()
     {
-        key_thread = std::thread(&GripperKeyboard::threadFunction, this);
+        key_thread = std::thread(&GripperKeyboard::keyListener, this);
     }
 
+    /**
+     * Joins the internal thread to the main thread
+     */
     void joinThread()
     {
         if(key_thread.joinable()) { key_thread.join(); }
     }
 
+    /**
+     * Sends appropriate command to the gripper
+     * @param _c the key pressed by the user
+     */
     void keyBindings(char _c)
     {
         switch(_c)
@@ -154,18 +168,29 @@ private:
 
 public:
 
+    /**
+     * Constructor for the class
+     */
     GripperKeyboard() : proceed(true), key('\0'), set_key(false),
-                        left_gripper("left"), right_gripper("right")
+                        left_gripper("left"), right_gripper("right") {}
+
+    /**
+     * Starts the Gripper keyboard
+     */
+    void run()
     {
+        // spinner is required for use of the Gripper object
+        ros::AsyncSpinner spinner(1);
+        spinner.start();
+
         ROS_INFO("Gripper keyboard starting...");
         ROS_INFO("You are now controlling the robot grippers");
         ROS_INFO("Enter your commands (or press ? for help)");
-    }
 
-    void run()
-    {
         startThread();
 
+        // listens for key presses from the internal thread
+        // continues while the ROS is running and the proceed flag is true
         ros::Rate r(10);
         while(ros::ok() && proceed)
         {
@@ -195,178 +220,3 @@ int main(int argc, char** argv)
     return 0;
 }
 
-
-/*
-
-
-bool           proceed; // flag to continue the thread and main loops
-char               key; // key to store the user input
-bool           set_key; // flag to know if the key was set
-std::mutex mtx_set_key; // mutex to protect the above flag
-
-void keyBindings(char _c, Gripper& left_gripper, Gripper& right_gripper)
-{
-    switch(_c)
-    {
-    case '?':
-        ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
-        ROS_INFO("q / Q : close gripper");
-        ROS_INFO("w / W : open gripper");
-        ROS_INFO("c / C : calibrate gripper");
-        ROS_INFO("x / X : is gripper calibrated?");
-        ROS_INFO("d / D : clear calibration");
-        ROS_INFO("t / T : type of gripper");
-        ROS_INFO("z / Z : is gripper enabled?");
-        ROS_INFO("v / V : does gripper have error?");
-        ROS_INFO("b / B : is gripper sucking?");
-        ROS_INFO("n / N : is gripper gripping?");
-        ROS_INFO("m / M : is gripper ready to grip?");
-        ROS_INFO("? : help");
-        ROS_INFO("e / E : exit");
-        break;
-    case 'q':
-        ROS_INFO("Closing left gripper");
-        left_gripper.close();
-        break;
-    case 'Q':
-        ROS_INFO("Closing right gripper");
-        right_gripper.close();
-        break;
-    case 'w':
-        ROS_INFO("Opening left gripper");
-        left_gripper.open();
-        break;
-    case 'W':
-        ROS_INFO("Opening right gripper");
-        right_gripper.open();
-        break;
-    case 'c':
-        ROS_INFO("Calibrating left gripper");
-        left_gripper.calibrate();
-        break;
-    case 'C':
-        ROS_INFO("Calibrating right gripper");
-        right_gripper.calibrate();
-        break;
-    case 'x':
-        ROS_INFO("Is left calibrated? %s", left_gripper.is_calibrated()? "Yes" : "No");
-        break;
-    case 'X':
-        ROS_INFO("Is right calibrated? %s", right_gripper.is_calibrated()? "Yes" : "No");
-        break;
-    case 'd':
-        ROS_INFO("Clear left gripper calibration");
-        left_gripper.clearCalibration();
-        break;
-    case 'D':
-        ROS_INFO("Clear right gripper calibration");
-        right_gripper.clearCalibration();
-        break;
-    case 't':
-        ROS_INFO("Left gripper type: %s", left_gripper.type().c_str());
-        break;
-    case 'T':
-        ROS_INFO("Right gripper type: %s", right_gripper.type().c_str());
-        break;
-    case 'z':
-        ROS_INFO("Is left enabled? %s", (left_gripper.is_enabled()? "Yes" : "No"));
-        break;
-    case 'Z':
-        ROS_INFO("Is right enabled? %s", (right_gripper.is_enabled()? "Yes" : "No"));
-        break;
-    case 'v':
-        ROS_INFO("Does left have error? %s", left_gripper.has_error()? "Yes" : "No");
-        break;
-    case 'V':
-        ROS_INFO("Does right have error? %s", right_gripper.has_error()? "Yes" : "No");
-        break;
-    case 'b':
-        ROS_INFO("Is left sucking? %s", left_gripper.is_sucking()? "Yes" : "No");
-        break;
-    case 'B':
-        ROS_INFO("Is right sucking? %s", right_gripper.is_sucking()? "Yes" : "No");
-        break;
-    case 'n':
-        ROS_INFO("Is left gripping? %s", left_gripper.is_gripping()? "Yes" : "No");
-        break;
-    case 'N':
-        ROS_INFO("Is right gripping? %s", right_gripper.is_gripping()? "Yes" : "No");
-        break;
-    case 'm':
-        ROS_INFO("Is left ready to grip? %s", left_gripper.is_ready_to_grip()? "Yes" : "No");
-        break;
-    case 'M':
-        ROS_INFO("Is right ready to grip? %s", right_gripper.is_ready_to_grip()? "Yes" : "No");
-        break;
-    default:
-        ROS_INFO("Not a valid command. Press ? for help, e to exit.");
-        break;
-    }
-}
-
-void threadFunction()
-{
-    char ch;
-
-    while(ros::ok() && proceed)
-    {
-        ROS_INFO("thread function running");
-        cin.get(ch);
-        cin.ignore();
-        ROS_INFO("Key entered: %c", ch);
-        key = ch;
-
-        std::lock_guard<std::mutex> lck(mtx_set_key);
-
-        if(ch == 'e' || ch == 'E')
-        {
-            proceed = false;
-        }
-        else
-        {
-            set_key = true;
-        }
-    }
-    printf("thread function closing\n");
-    return;
-}
-
-
-
-int main(int argc, char** argv)
-{
-    ros::init(argc, argv, "gripper_keyboard");
-
-    // gripper instantiation
-    Gripper left_gripper("left");
-    Gripper right_gripper("right");
-    ROS_INFO("You are now controlling the robot grippers");
-    ROS_INFO("Enter your commands (or press ? for help)...");
-
-    proceed = true;
-
-    std::thread thread(threadFunction);
-    ros::Rate r(10);
-
-    while(ros::ok() && proceed)
-    {
-        ROS_INFO("main thread running");
-        if(set_key)
-        {
-            keyBindings(key, left_gripper, right_gripper);
-
-            std::lock_guard<std::mutex> lck(mtx_set_key);
-            set_key = false;
-        }
-        r.sleep();
-    }
-
-    ROS_INFO("main thread closing");
-    proceed = false;
-    if(thread.joinable()) { thread.join(); }
-
-    // exit program
-    return 0;
-}
-
-*/

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -1,4 +1,133 @@
 #include "robot_interface/gripper.h"
+#include <thread>
+
+using namespace std;
+
+bool           proceed; // flag to continue the thread and main loops
+char               key; // key to store the user input
+bool           set_key; // flag to know if the key was set
+std::mutex mtx_set_key; // mutex to protect the above flag
+
+void keyBindings(char _c, Gripper& left_gripper, Gripper& right_gripper)
+{
+    switch(_c)
+    {
+    case '?':
+        ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
+        ROS_INFO("q / Q : close gripper");
+        ROS_INFO("w / W : open gripper");
+        ROS_INFO("c / C : calibrate gripper");
+        ROS_INFO("x / X : is gripper calibrated?");
+        ROS_INFO("d / D : clear calibration");
+        ROS_INFO("t / T : type of gripper");
+        ROS_INFO("z / Z : is gripper enabled?");
+        ROS_INFO("v / V : does gripper have error?");
+        ROS_INFO("b / B : is gripper sucking?");
+        ROS_INFO("n / N : is gripper gripping?");
+        ROS_INFO("m / M : is gripper ready to grip?");
+        ROS_INFO("? : help");
+        ROS_INFO("e / E : exit");
+        break;
+    case 'q':
+        ROS_INFO("Closing left gripper");
+        left_gripper.close();
+        break;
+    case 'Q':
+        ROS_INFO("Closing right gripper");
+        right_gripper.close();
+        break;
+    case 'w':
+        ROS_INFO("Opening left gripper");
+        left_gripper.open();
+        break;
+    case 'W':
+        ROS_INFO("Opening right gripper");
+        right_gripper.open();
+        break;
+    case 'c':
+        ROS_INFO("Calibrating left gripper");
+        left_gripper.calibrate();
+        break;
+    case 'C':
+        ROS_INFO("Calibrating right gripper");
+        right_gripper.calibrate();
+        break;
+    case 'x':
+        ROS_INFO("Is left calibrated? %s", left_gripper.is_calibrated()? "Yes" : "No");
+        break;
+    case 'X':
+        ROS_INFO("Is right calibrated? %s", right_gripper.is_calibrated()? "Yes" : "No");
+        break;
+    case 'd':
+        ROS_INFO("Clear left gripper calibration");
+        left_gripper.clearCalibration();
+        break;
+    case 'D':
+        ROS_INFO("Clear right gripper calibration");
+        right_gripper.clearCalibration();
+        break;
+    case 't':
+        ROS_INFO("Left gripper type: %s", left_gripper.type().c_str());
+        break;
+    case 'T':
+        ROS_INFO("Right gripper type: %s", right_gripper.type().c_str());
+        break;
+    case 'z':
+        ROS_INFO("Is left enabled? %s", (left_gripper.is_enabled()? "Yes" : "No"));
+        break;
+    case 'Z':
+        ROS_INFO("Is right enabled? %s", (right_gripper.is_enabled()? "Yes" : "No"));
+        break;
+    case 'v':
+        ROS_INFO("Does left have error? %s", left_gripper.has_error()? "Yes" : "No");
+        break;
+    case 'V':
+        ROS_INFO("Does right have error? %s", right_gripper.has_error()? "Yes" : "No");
+        break;
+    case 'b':
+        ROS_INFO("Is left sucking? %s", left_gripper.is_sucking()? "Yes" : "No");
+        break;
+    case 'B':
+        ROS_INFO("Is right sucking? %s", right_gripper.is_sucking()? "Yes" : "No");
+        break;
+    case 'n':
+        ROS_INFO("Is left gripping? %s", left_gripper.is_gripping()? "Yes" : "No");
+        break;
+    case 'N':
+        ROS_INFO("Is right gripping? %s", right_gripper.is_gripping()? "Yes" : "No");
+        break;
+    case 'm':
+        ROS_INFO("Is left ready to grip? %s", left_gripper.is_ready_to_grip()? "Yes" : "No");
+        break;
+    case 'M':
+        ROS_INFO("Is right ready to grip? %s", right_gripper.is_ready_to_grip()? "Yes" : "No");
+        break;
+    default:
+        ROS_INFO("Not a valid command. Press ? for help, e to exit.");
+        break;
+    }
+}
+
+void threadFunction()
+{
+    char ch;
+    while(proceed)
+    {
+        cin.get(ch);
+        cin.ignore();
+        ROS_INFO("Key entered: %c", ch);
+        key = ch;
+
+        std::lock_guard<std::mutex> lck(mtx_set_key);
+        set_key = true;
+
+        if(ch == 'e' || ch == 'E')
+        {
+            proceed = false;
+        }
+    }
+    return;
+}
 
 int main(int argc, char** argv)
 {
@@ -7,121 +136,29 @@ int main(int argc, char** argv)
     spinner.start();
 
     // gripper instantiation
-    Gripper left_gripper("right");
+    Gripper left_gripper("left");
     Gripper right_gripper("right");
-
     ROS_INFO("You are now controlling the robot grippers");
+    ROS_INFO("Enter your commands (or press ? for help)...");
 
-    // gripper keys
-    while(ros::ok())
+    proceed = true;
+
+    std::thread thread(threadFunction);
+
+    while(proceed)
     {
-        ROS_INFO("Enter your command (or press ? for help)...");
-
-        char c = std::cin.get();
-        std::cin.ignore();
-        ROS_INFO("Key entered: %c", c);
-
-        switch(c)
+        if(set_key)
         {
-        case '?':
-            ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
-            ROS_INFO("q / Q : close gripper");
-            ROS_INFO("w / W : open gripper");
-            ROS_INFO("c / C : calibrate gripper");
-            ROS_INFO("x / X : is gripper calibrated?");
-            ROS_INFO("d / D : clear calibration");
-            ROS_INFO("t / T : type of gripper");
-            ROS_INFO("z / Z : is gripper enabled?");
-            ROS_INFO("v / V : does gripper have error?");
-            ROS_INFO("b / B : is gripper sucking?");
-            ROS_INFO("n / N : is gripper gripping?");
-            ROS_INFO("m / M : is gripper ready to grip?");
-            ROS_INFO("? : help");
-            ROS_INFO("e : exit");
-            break;
-        case 'q':
-            ROS_INFO("Closing left gripper");
-            left_gripper.close();
-            break;
-        case 'Q':
-            ROS_INFO("Closing right gripper");
-            right_gripper.close();
-            break;
-        case 'w':
-            ROS_INFO("Opening left gripper");
-            left_gripper.open();
-            break;
-        case 'W':
-            ROS_INFO("Opening right gripper");
-            right_gripper.open();
-            break;
-        case 'c':
-            ROS_INFO("Calibrating left gripper");
-            left_gripper.calibrate();
-            break;
-        case 'C':
-            ROS_INFO("Calibrating right gripper");
-            right_gripper.calibrate();
-            break;
-        case 'x':
-            ROS_INFO("Is left calibrated? %s", left_gripper.is_calibrated()? "Yes" : "No");
-            break;
-        case 'X':
-            ROS_INFO("Is right calibrated? %s", right_gripper.is_calibrated()? "Yes" : "No");
-            break;
-        case 'd':
-            ROS_INFO("Clear left gripper calibration");
-            left_gripper.clearCalibration();
-            break;
-        case 'D':
-            ROS_INFO("Clear right gripper calibration");
-            right_gripper.clearCalibration();
-            break;
-        case 't':
-            ROS_INFO("Left gripper type: %s", left_gripper.type().c_str());
-            break;
-        case 'T':
-            ROS_INFO("Right gripper type: %s", right_gripper.type().c_str());
-            break;
-        case 'z':
-            ROS_INFO("Is left enabled? %s", (left_gripper.is_enabled()? "Yes" : "No"));
-            break;
-        case 'Z':
-            ROS_INFO("Is right enabled? %s", (right_gripper.is_enabled()? "Yes" : "No"));
-            break;
-        case 'v':
-            ROS_INFO("Does left have error? %s", left_gripper.has_error()? "Yes" : "No");
-            break;
-        case 'V':
-            ROS_INFO("Does right have error? %s", right_gripper.has_error()? "Yes" : "No");
-            break;
-        case 'b':
-            ROS_INFO("Is left sucking? %s", left_gripper.is_sucking()? "Yes" : "No");
-            break;
-        case 'B':
-            ROS_INFO("Is right sucking? %s", right_gripper.is_sucking()? "Yes" : "No");
-            break;
-        case 'n':
-            ROS_INFO("Is left gripping? %s", left_gripper.is_gripping()? "Yes" : "No");
-            break;
-        case 'N':
-            ROS_INFO("Is right gripping? %s", right_gripper.is_gripping()? "Yes" : "No");
-            break;
-        case 'm':
-            ROS_INFO("Is left ready to grip? %s", left_gripper.is_ready_to_grip()? "Yes" : "No");
-            break;
-        case 'M':
-            ROS_INFO("Is right ready to grip? %s", right_gripper.is_ready_to_grip()? "Yes" : "No");
-            break;
-        case 'e':
-            ROS_INFO("Exiting...");
-            return 0;
-        default:
-            ROS_INFO("Not a valid command. Press ? for help, e to exit.");
-            break;
+            keyBindings(key, left_gripper, right_gripper);
+
+            std::lock_guard<std::mutex> lck(mtx_set_key);
+            set_key = false;
         }
-        ros::spinOnce();
     }
+
+    if(thread.joinable()) { thread.join(); }
+
+    // exit program
     return 0;
 }
 

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -3,6 +3,202 @@
 
 using namespace std;
 
+class GripperKeyboard
+{
+private:
+
+    bool           proceed;
+    char               key;
+    bool           set_key;
+
+    Gripper left_gripper;
+    Gripper right_gripper;
+
+    std::mutex mtx_set_key;
+    std::thread key_thread;
+
+    void threadFunction()
+    {
+        char ch;
+
+        while(ros::ok() && proceed)
+        {
+            cin.get(ch);
+            cin.ignore();
+            ROS_INFO("Key entered: %c", ch);
+            key = ch;
+
+            std::lock_guard<std::mutex> lck(mtx_set_key);
+
+            if(ch == 'e' || ch == 'E')
+            {
+                proceed = false;
+            }
+            else
+            {
+                set_key = true;
+            }
+        }
+        return;
+    }
+
+    void startThread()
+    {
+        key_thread = std::thread(&GripperKeyboard::threadFunction, this);
+    }
+
+    void joinThread()
+    {
+        if(key_thread.joinable()) { key_thread.join(); }
+    }
+
+    void keyBindings(char _c)
+    {
+        switch(_c)
+        {
+        case '?':
+            ROS_INFO("Available commands: (lowercase for left gripper, uppercase for right gripper)");
+            ROS_INFO("q / Q : close gripper");
+            ROS_INFO("w / W : open gripper");
+            ROS_INFO("c / C : calibrate gripper");
+            ROS_INFO("x / X : is gripper calibrated?");
+            ROS_INFO("d / D : clear calibration");
+            ROS_INFO("t / T : type of gripper");
+            ROS_INFO("z / Z : is gripper enabled?");
+            ROS_INFO("v / V : does gripper have error?");
+            ROS_INFO("b / B : is gripper sucking?");
+            ROS_INFO("n / N : is gripper gripping?");
+            ROS_INFO("m / M : is gripper ready to grip?");
+            ROS_INFO("? : help");
+            ROS_INFO("e / E : exit");
+            break;
+        case 'q':
+            ROS_INFO("Closing left gripper");
+            left_gripper.close();
+            break;
+        case 'Q':
+            ROS_INFO("Closing right gripper");
+            right_gripper.close();
+            break;
+        case 'w':
+            ROS_INFO("Opening left gripper");
+            left_gripper.open();
+            break;
+        case 'W':
+            ROS_INFO("Opening right gripper");
+            right_gripper.open();
+            break;
+        case 'c':
+            ROS_INFO("Calibrating left gripper");
+            left_gripper.calibrate();
+            break;
+        case 'C':
+            ROS_INFO("Calibrating right gripper");
+            right_gripper.calibrate();
+            break;
+        case 'x':
+            ROS_INFO("Is left calibrated? %s", left_gripper.is_calibrated()? "Yes" : "No");
+            break;
+        case 'X':
+            ROS_INFO("Is right calibrated? %s", right_gripper.is_calibrated()? "Yes" : "No");
+            break;
+        case 'd':
+            ROS_INFO("Clear left gripper calibration");
+            left_gripper.clearCalibration();
+            break;
+        case 'D':
+            ROS_INFO("Clear right gripper calibration");
+            right_gripper.clearCalibration();
+            break;
+        case 't':
+            ROS_INFO("Left gripper type: %s", left_gripper.type().c_str());
+            break;
+        case 'T':
+            ROS_INFO("Right gripper type: %s", right_gripper.type().c_str());
+            break;
+        case 'z':
+            ROS_INFO("Is left enabled? %s", (left_gripper.is_enabled()? "Yes" : "No"));
+            break;
+        case 'Z':
+            ROS_INFO("Is right enabled? %s", (right_gripper.is_enabled()? "Yes" : "No"));
+            break;
+        case 'v':
+            ROS_INFO("Does left have error? %s", left_gripper.has_error()? "Yes" : "No");
+            break;
+        case 'V':
+            ROS_INFO("Does right have error? %s", right_gripper.has_error()? "Yes" : "No");
+            break;
+        case 'b':
+            ROS_INFO("Is left sucking? %s", left_gripper.is_sucking()? "Yes" : "No");
+            break;
+        case 'B':
+            ROS_INFO("Is right sucking? %s", right_gripper.is_sucking()? "Yes" : "No");
+            break;
+        case 'n':
+            ROS_INFO("Is left gripping? %s", left_gripper.is_gripping()? "Yes" : "No");
+            break;
+        case 'N':
+            ROS_INFO("Is right gripping? %s", right_gripper.is_gripping()? "Yes" : "No");
+            break;
+        case 'm':
+            ROS_INFO("Is left ready to grip? %s", left_gripper.is_ready_to_grip()? "Yes" : "No");
+            break;
+        case 'M':
+            ROS_INFO("Is right ready to grip? %s", right_gripper.is_ready_to_grip()? "Yes" : "No");
+            break;
+        default:
+            ROS_INFO("Not a valid command. Press ? for help, e to exit.");
+            break;
+        }
+    }
+
+public:
+
+    GripperKeyboard() : proceed(true), key('\0'), set_key(false),
+                        left_gripper("left"), right_gripper("right")
+    {
+        ROS_INFO("Gripper keyboard starting...");
+        ROS_INFO("You are now controlling the robot grippers");
+        ROS_INFO("Enter your commands (or press ? for help)");
+    }
+
+    void run()
+    {
+        startThread();
+
+        ros::Rate r(10);
+        while(ros::ok() && proceed)
+        {
+            if(set_key)
+            {
+                keyBindings(key);
+
+                std::lock_guard<std::mutex> lck(mtx_set_key);
+                set_key = false;
+            }
+            r.sleep();
+        }
+
+        ROS_INFO("Gripper keyboard closing...");
+        proceed = false;
+        joinThread();
+    }
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "gripper_keyboard");
+
+    GripperKeyboard gk;
+    gk.run();
+
+    return 0;
+}
+
+
+/*
+
+
 bool           proceed; // flag to continue the thread and main loops
 char               key; // key to store the user input
 bool           set_key; // flag to know if the key was set
@@ -111,29 +307,35 @@ void keyBindings(char _c, Gripper& left_gripper, Gripper& right_gripper)
 void threadFunction()
 {
     char ch;
-    while(proceed)
+
+    while(ros::ok() && proceed)
     {
+        ROS_INFO("thread function running");
         cin.get(ch);
         cin.ignore();
         ROS_INFO("Key entered: %c", ch);
         key = ch;
 
         std::lock_guard<std::mutex> lck(mtx_set_key);
-        set_key = true;
 
         if(ch == 'e' || ch == 'E')
         {
             proceed = false;
         }
+        else
+        {
+            set_key = true;
+        }
     }
+    printf("thread function closing\n");
     return;
 }
+
+
 
 int main(int argc, char** argv)
 {
     ros::init(argc, argv, "gripper_keyboard");
-    ros::AsyncSpinner spinner(1);
-    spinner.start();
 
     // gripper instantiation
     Gripper left_gripper("left");
@@ -144,9 +346,11 @@ int main(int argc, char** argv)
     proceed = true;
 
     std::thread thread(threadFunction);
+    ros::Rate r(10);
 
-    while(proceed)
+    while(ros::ok() && proceed)
     {
+        ROS_INFO("main thread running");
         if(set_key)
         {
             keyBindings(key, left_gripper, right_gripper);
@@ -154,11 +358,15 @@ int main(int argc, char** argv)
             std::lock_guard<std::mutex> lck(mtx_set_key);
             set_key = false;
         }
+        r.sleep();
     }
 
+    ROS_INFO("main thread closing");
+    proceed = false;
     if(thread.joinable()) { thread.join(); }
 
     // exit program
     return 0;
 }
 
+*/

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -163,11 +163,9 @@ private:
             ROS_INFO("Is right ready to grip? %s", right_gripper.is_ready_to_grip()? "Yes" : "No");
             break;
         case 'r':
-            ROS_INFO("Rebooting left gripper");
             left_gripper.reboot();
             break;
         case 'R':
-            ROS_INFO("Rebooting right gripper");
             right_gripper.reboot();
             break;
         default:
@@ -209,6 +207,7 @@ public:
             }
             r.sleep();
         }
+        std::lock_guard<std::mutex> lck(mtx_set_key);
         proceed = false;
     }
 

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -84,6 +84,7 @@ private:
             ROS_INFO("b / B : is gripper sucking?");
             ROS_INFO("n / N : is gripper gripping?");
             ROS_INFO("m / M : is gripper ready to grip?");
+            ROS_INFO("r / R : reboot gripper");
             ROS_INFO("? : help");
             ROS_INFO("e / E : exit");
             break;
@@ -118,11 +119,11 @@ private:
             ROS_INFO("Is right calibrated? %s", right_gripper.is_calibrated()? "Yes" : "No");
             break;
         case 'd':
-            ROS_INFO("Clear left gripper calibration");
+            ROS_INFO("Clearing left gripper calibration");
             left_gripper.clearCalibration();
             break;
         case 'D':
-            ROS_INFO("Clear right gripper calibration");
+            ROS_INFO("Clearing right gripper calibration");
             right_gripper.clearCalibration();
             break;
         case 't':
@@ -161,6 +162,14 @@ private:
         case 'M':
             ROS_INFO("Is right ready to grip? %s", right_gripper.is_ready_to_grip()? "Yes" : "No");
             break;
+        case 'r':
+            ROS_INFO("Rebooting left gripper");
+            left_gripper.reboot();
+            break;
+        case 'R':
+            ROS_INFO("Rebooting right gripper");
+            right_gripper.reboot();
+            break;
         default:
             ROS_INFO("Not a valid command. Press ? for help, e to exit.");
             break;
@@ -173,7 +182,7 @@ public:
      * Constructor for the class
      */
     GripperKeyboard() : proceed(true), key('\0'), set_key(false),
-                        left_gripper("left"), right_gripper("right") {}
+                        left_gripper("left", true), right_gripper("right", true) {}
 
     /**
      * Starts the Gripper keyboard
@@ -200,16 +209,17 @@ public:
             }
             r.sleep();
         }
-
-        ROS_INFO("Gripper keyboard closing...");
         proceed = false;
-        joinThread();
     }
 
     /**
      * Destructor for the class
      */
-    ~GripperKeyboard() {}
+    ~GripperKeyboard()
+    {
+        ROS_INFO("Gripper keyboard closing...");
+        joinThread();
+    }
 };
 
 int main(int argc, char** argv)

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -7,9 +7,8 @@ int main(int argc, char** argv)
     spinner.start();
 
     // gripper instantiation
-    Gripper *left_gripper = NULL, *right_gripper = NULL;
-    left_gripper = new Gripper("left");
-    right_gripper = new Gripper("right");
+    Gripper left_gripper("right");
+    Gripper right_gripper("right");
 
     ROS_INFO("You are now controlling the robot grippers");
 
@@ -42,77 +41,77 @@ int main(int argc, char** argv)
             break;
         case 'q':
             ROS_INFO("Closing left gripper");
-            left_gripper->close();
+            left_gripper.close();
             break;
         case 'Q':
             ROS_INFO("Closing right gripper");
-            right_gripper->close();
+            right_gripper.close();
             break;
         case 'w':
             ROS_INFO("Opening left gripper");
-            left_gripper->open();
+            left_gripper.open();
             break;
         case 'W':
             ROS_INFO("Opening right gripper");
-            right_gripper->open();
+            right_gripper.open();
             break;
         case 'c':
             ROS_INFO("Calibrating left gripper");
-            left_gripper->calibrate();
+            left_gripper.calibrate();
             break;
         case 'C':
             ROS_INFO("Calibrating right gripper");
-            right_gripper->calibrate();
+            right_gripper.calibrate();
             break;
         case 'x':
-            ROS_INFO("Is left calibrated? %s", left_gripper->is_calibrated()? "Yes" : "No");
+            ROS_INFO("Is left calibrated? %s", left_gripper.is_calibrated()? "Yes" : "No");
             break;
         case 'X':
-            ROS_INFO("Is right calibrated? %s", right_gripper->is_calibrated()? "Yes" : "No");
+            ROS_INFO("Is right calibrated? %s", right_gripper.is_calibrated()? "Yes" : "No");
             break;
         case 'd':
             ROS_INFO("Clear left gripper calibration");
-            left_gripper->clearCalibration();
+            left_gripper.clearCalibration();
             break;
         case 'D':
             ROS_INFO("Clear right gripper calibration");
-            right_gripper->clearCalibration();
+            right_gripper.clearCalibration();
             break;
         case 't':
-            ROS_INFO("Left gripper type: %s", left_gripper->type().c_str());
+            ROS_INFO("Left gripper type: %s", left_gripper.type().c_str());
             break;
         case 'T':
-            ROS_INFO("Right gripper type: %s", right_gripper->type().c_str());
+            ROS_INFO("Right gripper type: %s", right_gripper.type().c_str());
             break;
         case 'z':
-            ROS_INFO("Is left enabled? %s", (left_gripper->is_enabled()? "Yes" : "No"));
+            ROS_INFO("Is left enabled? %s", (left_gripper.is_enabled()? "Yes" : "No"));
             break;
         case 'Z':
-            ROS_INFO("Is right enabled? %s", (right_gripper->is_enabled()? "Yes" : "No"));
+            ROS_INFO("Is right enabled? %s", (right_gripper.is_enabled()? "Yes" : "No"));
             break;
         case 'v':
-            ROS_INFO("Does left have error? %s", left_gripper->has_error()? "Yes" : "No");
+            ROS_INFO("Does left have error? %s", left_gripper.has_error()? "Yes" : "No");
             break;
         case 'V':
-            ROS_INFO("Does right have error? %s", right_gripper->has_error()? "Yes" : "No");
+            ROS_INFO("Does right have error? %s", right_gripper.has_error()? "Yes" : "No");
             break;
         case 'b':
-            ROS_INFO("Is left sucking? %s", left_gripper->is_sucking()? "Yes" : "No");
+            ROS_INFO("Is left sucking? %s", left_gripper.is_sucking()? "Yes" : "No");
             break;
         case 'B':
-            ROS_INFO("Is right sucking? %s", right_gripper->is_sucking()? "Yes" : "No");
+            ROS_INFO("Is right sucking? %s", right_gripper.is_sucking()? "Yes" : "No");
             break;
         case 'n':
-            ROS_INFO("Is left gripping? %s", left_gripper->is_gripping()? "Yes" : "No");
+            ROS_INFO("Is left gripping? %s", left_gripper.is_gripping()? "Yes" : "No");
             break;
         case 'N':
-            ROS_INFO("Is right gripping? %s", right_gripper->is_gripping()? "Yes" : "No");
+            ROS_INFO("Is right gripping? %s", right_gripper.is_gripping()? "Yes" : "No");
             break;
         case 'm':
-            ROS_INFO("Is left ready to grip? %s", left_gripper->is_ready_to_grip()? "Yes" : "No");
+            ROS_INFO("Is left ready to grip? %s", left_gripper.is_ready_to_grip()? "Yes" : "No");
             break;
         case 'M':
-            ROS_INFO("Is right ready to grip? %s", right_gripper->is_ready_to_grip()? "Yes" : "No");
+            ROS_INFO("Is right ready to grip? %s", right_gripper.is_ready_to_grip()? "Yes" : "No");
             break;
         case 'e':
             ROS_INFO("Exiting...");
@@ -123,11 +122,6 @@ int main(int argc, char** argv)
         }
         ros::spinOnce();
     }
-
-    delete left_gripper;
-    delete right_gripper;
-    left_gripper = right_gripper = 0;
-
     return 0;
 }
 

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -205,6 +205,11 @@ public:
         proceed = false;
         joinThread();
     }
+
+    /**
+     * Destructor for the class
+     */
+    ~GripperKeyboard() {}
 };
 
 int main(int argc, char** argv)

--- a/baxter_collaboration_lib/test/gripper_keyboard.cpp
+++ b/baxter_collaboration_lib/test/gripper_keyboard.cpp
@@ -180,10 +180,6 @@ public:
      */
     void run()
     {
-        // spinner is required for use of the Gripper object
-        ros::AsyncSpinner spinner(1);
-        spinner.start();
-
         ROS_INFO("Gripper keyboard starting...");
         ROS_INFO("You are now controlling the robot grippers");
         ROS_INFO("Enter your commands (or press ? for help)");

--- a/baxter_collaboration_lib/test/test_gripper.cpp
+++ b/baxter_collaboration_lib/test/test_gripper.cpp
@@ -189,10 +189,10 @@ TEST(GripperTest, testCalibration)
    gt.sendPropertiesElectric();
 
    gr.calibrate();
-   
+
    baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
 
-   EXPECT_TRUE(_state.calibrated == baxter_core_msgs::EndEffectorState::STATE_TRUE);
+  // EXPECT_TRUE(_state.calibrated == baxter_core_msgs::EndEffectorState::STATE_TRUE);
 
 //   gr.clearCalibration();
 //   _state = gr.getGripperState();

--- a/baxter_collaboration_lib/test/test_gripper.cpp
+++ b/baxter_collaboration_lib/test/test_gripper.cpp
@@ -2,7 +2,8 @@
 #include "robot_interface/gripper.h"
 #include <iostream>
 
-using namespace std;
+using namespace              std;
+using namespace baxter_core_msgs;
 
 class gripperTester
 {
@@ -11,82 +12,79 @@ class gripperTester
     std::string               limb;
     ros::Publisher        prop_pub;
     ros::Publisher       state_pub;
-    ros::Subscriber        cmd_sub; 
-    std::mutex    mutex_properties; 
+    ros::Subscriber        cmd_sub;
+    std::mutex    mutex_properties;
     ros::AsyncSpinner      spinner;
+
+    void commandCb(baxter_core_msgs::EndEffectorCommand msg)
+    {
+        cmd_value = msg.command;
+    }
 
 public:
     std::string cmd_value;
 
-    explicit gripperTester(std::string _name, std::string _limb) : 
-                                name(_name), limb(_limb), spinner(1)
+    explicit gripperTester(std::string _name, std::string _limb) :
+                                name(_name), limb(_limb), spinner(4)
     {
-        prop_pub = nh.advertise<baxter_core_msgs::EndEffectorProperties>(
-                                 "/robot/end_effector/" + limb + "_gripper/properties", 1, true);
+        prop_pub = nh.advertise<EndEffectorProperties>("/robot/end_effector/" +
+                                        limb + "_gripper/properties", 1, true);
 
-        state_pub = nh.advertise<baxter_core_msgs::EndEffectorState>(
-                                 "/robot/end_effector/" + limb + "_gripper/state", 1, true);
-   
+        state_pub = nh.advertise<EndEffectorState>("/robot/end_effector/" +
+                                         limb + "_gripper/state", 1, true);
+
         cmd_sub = nh.subscribe("/robot/end_effector/" + limb + "_gripper/command",
-                                 SUBSCRIBER_BUFFER, &gripperTester::commandCb, this);
-        
+                              SUBSCRIBER_BUFFER, &gripperTester::commandCb, this);
+
         spinner.start();
 
         // sleep to wait for the publishers to be ready
         ros::Duration(.5).sleep();
     }
 
-    void commandCb(const baxter_core_msgs::EndEffectorCommand &msg)
-    {
-        cmd_value = msg.command;
-    }
-
     // Publishes properties of the suction cup gripper
-    void sendPropertiesSuction()
+    void sendPropSuction()
     {
         //publish the properties then make sure they are correctly set in the tests
-        baxter_core_msgs::EndEffectorProperties prop;
+        EndEffectorProperties prop;
         prop.ui_type = 1u;
-        prop_pub.publish(prop);   
+        prop_pub.publish(prop);
     }
 
     // Publishes the properties of the electric gripper
-    void sendPropertiesElectric()
+    void sendPropElectric()
     {
-        baxter_core_msgs::EndEffectorProperties prop;
+        EndEffectorProperties prop;
         prop.ui_type = 2u;
-        prop_pub.publish(prop); 
+        prop_pub.publish(prop);
     }
 
     // Publishes the state of the gripper
     void sendState()
     {
         //publish the state then make sure it's correctly set in the tests
-        baxter_core_msgs::EndEffectorState state;
+        EndEffectorState state;
 
-        state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
-        state.enabled    = baxter_core_msgs::EndEffectorState::STATE_TRUE;
-        state.error      = baxter_core_msgs::EndEffectorState::STATE_FALSE;
-        state.gripping   = baxter_core_msgs::EndEffectorState::STATE_FALSE;
-        state.missed     = baxter_core_msgs::EndEffectorState::STATE_FALSE;
-        state.ready      = baxter_core_msgs::EndEffectorState::STATE_TRUE;
-        state.moving     = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        state.calibrated = EndEffectorState::STATE_TRUE;
+        state.enabled    = EndEffectorState::STATE_TRUE;
+        state.error      = EndEffectorState::STATE_FALSE;
+        state.gripping   = EndEffectorState::STATE_FALSE;
+        state.missed     = EndEffectorState::STATE_FALSE;
+        state.ready      = EndEffectorState::STATE_TRUE;
+        state.moving     = EndEffectorState::STATE_TRUE;
 
         state_pub.publish(state);
     }
 };
 
 // Waits for published command to be received
-void waitTime(std::string _expected_cmd, std::string &_cmd)
+void wait(std::string _expected_cmd, std::string &_cmd)
 {
     ros::Rate r(100);
-    int flag = 0;
-    while (flag == 0)
+
+    while (ros::ok())
     {
-        if (_expected_cmd == _cmd) 
-        { 
-            flag = 1; 
-        }
+        if (_expected_cmd == _cmd) { return; }
         r.sleep();
     }
 }
@@ -94,69 +92,66 @@ void waitTime(std::string _expected_cmd, std::string &_cmd)
 TEST(GripperTest, testPropertiesAndStateSubscriber)
 {
     std::string    limb = "left";
-    bool use_robot =  true;
 
-    gripperTester gt("gripper" , "left");
-    gt.sendPropertiesSuction();
+    gripperTester gt("gripper", "left");
+    gt.sendPropSuction();
     gt.sendState();
 
-    Gripper gr(limb, use_robot);
+    Gripper gr(limb);
 
     EXPECT_TRUE(      gr.is_enabled());
-    EXPECT_TRUE(   gr.is_calibrated());  
+    EXPECT_TRUE(   gr.is_calibrated());
     EXPECT_TRUE(gr.is_ready_to_grip());
     EXPECT_TRUE(      gr.is_sucking());
-    EXPECT_FALSE(     gr.is_gripping());
+    EXPECT_FALSE(    gr.is_gripping());
     EXPECT_FALSE(      gr.has_error());
-    
+
     EXPECT_EQ("left", gr.getGripperLimb());
 
-    baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
+    EndEffectorState _state = gr.getGripperState();
 
-    EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_TRUE);
-    EXPECT_EQ(_state.enabled    , baxter_core_msgs::EndEffectorState::STATE_TRUE);
-    EXPECT_EQ(_state.error      , baxter_core_msgs::EndEffectorState::STATE_FALSE);
-    EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_FALSE);
-    EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_FALSE);
-    EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_TRUE);
-    EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_TRUE);    
+    EXPECT_EQ(_state.calibrated, EndEffectorState::STATE_TRUE);
+    EXPECT_EQ(_state.enabled   , EndEffectorState::STATE_TRUE);
+    EXPECT_EQ(_state.error     , EndEffectorState::STATE_FALSE);
+    EXPECT_EQ(_state.gripping  , EndEffectorState::STATE_FALSE);
+    EXPECT_EQ(_state.missed    , EndEffectorState::STATE_FALSE);
+    EXPECT_EQ(_state.ready     , EndEffectorState::STATE_TRUE);
+    EXPECT_EQ(_state.moving    , EndEffectorState::STATE_TRUE);
 }
 
 TEST(GripperTest, testDefaultStates)
-{ 
+{
    std::string    limb = "left";
-   bool use_robot =  true;
 
-   Gripper gr(limb, use_robot);
-   baxter_core_msgs::EndEffectorState _state;
+   Gripper gr(limb);
+   EndEffectorState _state;
    _state = gr.getGripperState();
 
-  EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-  EXPECT_EQ(_state.enabled    , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-  EXPECT_EQ(_state.error      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-  EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-  EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-  EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-  EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-    
-} 
+  EXPECT_EQ(_state.calibrated, EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.enabled   , EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.error     , EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.gripping  , EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.missed    , EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.ready     , EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.moving    , EndEffectorState::STATE_UNKNOWN);
+
+}
 
 TEST(GripperTest, testElectricCalibration)
-{ 
+{
    std::string    limb = "left";
-   bool       use_robot =  true;
 
    gripperTester gt("gripper", "left");
-   gt.sendPropertiesElectric();
+   gt.sendPropElectric();
 
-   Gripper gr(limb, use_robot);
+   Gripper gr(limb);
    gr.calibrate();
-   
+
    // The expected command we want to receive
-   std::string calibrate_cmd = baxter_core_msgs::EndEffectorCommand::CMD_CALIBRATE;
+   std::string calibrate_cmd = EndEffectorCommand::CMD_CALIBRATE;
 
    // Wait so that the gripper has time to publish the command we want to test
-   waitTime(calibrate_cmd, gt.cmd_value);
+   wait(calibrate_cmd, gt.cmd_value);
 
    EXPECT_EQ(calibrate_cmd, gt.cmd_value);
 }
@@ -164,66 +159,64 @@ TEST(GripperTest, testElectricCalibration)
 TEST(GripperTest, testElectricMethods)
 {
    std::string    limb = "left";
-   bool       use_robot =  true;
 
    gripperTester gt("gripper", "left");
-   gt.sendPropertiesElectric();
+   gt.sendPropElectric();
 
-   Gripper gr(limb, use_robot);
+   Gripper gr(limb);
 
-   std::string expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_CALIBRATE;
+   std::string expected_cmd = EndEffectorCommand::CMD_CALIBRATE;
 
-   // Calling close() should first calibrate the gripper, and then grip 
+   // Calling close() should first calibrate the gripper, and then grip
    gr.close();
    EXPECT_EQ(expected_cmd, gt.cmd_value);
-   
-   // Wait so that the gripper has time to publish the command we want to test
-   waitTime(expected_cmd, gt.cmd_value);
 
-   expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_GO;
+   // Wait so that the gripper has time to publish the command we want to test
+   wait(expected_cmd, gt.cmd_value);
+
+   expected_cmd = EndEffectorCommand::CMD_GO;
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 
    // Test open() method
-   expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_GO;
+   expected_cmd = EndEffectorCommand::CMD_GO;
    gr.open();
 
    // Wait so that the gripper has time to publish the command we want to test
-   waitTime(expected_cmd, gt.cmd_value);
+   wait(expected_cmd, gt.cmd_value);
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 }
 
 TEST(GripperTest, testSuctionMethods)
 {
    std::string    limb = "left";
-   bool       use_robot =  true;
 
    gripperTester gt("gripper", "left");
-   gt.sendPropertiesSuction();
+   gt.sendPropSuction();
 
-   Gripper gr(limb, use_robot);
+   Gripper gr(limb);
 
    // The expected command we want to receive
-   std::string expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_CONFIGURE;
+   std::string expected_cmd = EndEffectorCommand::CMD_CONFIGURE;
 
    // Wait so that the gripper has time to publish the command we want to test
-   waitTime(expected_cmd, gt.cmd_value);
+   wait(expected_cmd, gt.cmd_value);
 
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 
    gr.close();
-   expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_GO;
+   expected_cmd = EndEffectorCommand::CMD_GO;
 
    // Wait so that the gripper has time to publish the command we want to test
-   waitTime(expected_cmd, gt.cmd_value);
+   wait(expected_cmd, gt.cmd_value);
 
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 
    //Test open() method and close() method (called in open() definition)
    gr.open();
-   expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_RELEASE;
+   expected_cmd = EndEffectorCommand::CMD_RELEASE;
 
    // Wait so that the gripper has time to publish the command we want to test
-   waitTime(expected_cmd, gt.cmd_value);
+   wait(expected_cmd, gt.cmd_value);
 
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 }

--- a/baxter_collaboration_lib/test/test_gripper.cpp
+++ b/baxter_collaboration_lib/test/test_gripper.cpp
@@ -76,6 +76,21 @@ public:
     }
 };
 
+// Waits for published command to be received
+void waitTime(std::string _expected_cmd, std::string &_cmd)
+{
+    ros::Rate r(100);
+    int flag = 0;
+    while (flag == 0)
+    {
+        if (_expected_cmd == _cmd) 
+        { 
+            flag = 1; 
+        }
+        r.sleep();
+    }
+}
+
 TEST(GripperTest, testPropertiesAndStateSubscriber)
 {
     std::string    limb = "left";
@@ -137,11 +152,11 @@ TEST(GripperTest, testElectricCalibration)
    Gripper gr(limb, use_robot);
    gr.calibrate();
    
-   // Wait so that the gripper has time to publish the command we want to test
-   ros::Duration(1).sleep();
-
    // The expected command we want to receive
    std::string calibrate_cmd = baxter_core_msgs::EndEffectorCommand::CMD_CALIBRATE;
+
+   // Wait so that the gripper has time to publish the command we want to test
+   waitTime(calibrate_cmd, gt.cmd_value);
 
    EXPECT_EQ(calibrate_cmd, gt.cmd_value);
 }
@@ -163,7 +178,7 @@ TEST(GripperTest, testElectricMethods)
    EXPECT_EQ(expected_cmd, gt.cmd_value);
    
    // Wait so that the gripper has time to publish the command we want to test
-   ros::Duration(1).sleep();
+   waitTime(expected_cmd, gt.cmd_value);
 
    expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_GO;
    EXPECT_EQ(expected_cmd, gt.cmd_value);
@@ -173,7 +188,7 @@ TEST(GripperTest, testElectricMethods)
    gr.open();
 
    // Wait so that the gripper has time to publish the command we want to test
-   ros::Duration(1).sleep();
+   waitTime(expected_cmd, gt.cmd_value);
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 }
 
@@ -187,11 +202,11 @@ TEST(GripperTest, testSuctionMethods)
 
    Gripper gr(limb, use_robot);
 
-   // Wait so that the gripper has time to publish the command we want to test
-   ros::Duration(1).sleep();
-
    // The expected command we want to receive
    std::string expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_CONFIGURE;
+
+   // Wait so that the gripper has time to publish the command we want to test
+   waitTime(expected_cmd, gt.cmd_value);
 
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 
@@ -199,7 +214,7 @@ TEST(GripperTest, testSuctionMethods)
    expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_GO;
 
    // Wait so that the gripper has time to publish the command we want to test
-   ros::Duration(1).sleep();
+   waitTime(expected_cmd, gt.cmd_value);
 
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 
@@ -208,7 +223,7 @@ TEST(GripperTest, testSuctionMethods)
    expected_cmd = baxter_core_msgs::EndEffectorCommand::CMD_RELEASE;
 
    // Wait so that the gripper has time to publish the command we want to test
-   ros::Duration(1).sleep();
+   waitTime(expected_cmd, gt.cmd_value);
 
    EXPECT_EQ(expected_cmd, gt.cmd_value);
 }

--- a/baxter_collaboration_lib/test/test_gripper.cpp
+++ b/baxter_collaboration_lib/test/test_gripper.cpp
@@ -44,7 +44,7 @@ public:
 
         baxter_core_msgs::EndEffectorState state;
         
-        state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        state.calibrated = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
         state.enabled    = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
         state.error      = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
         state.gripping   = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
@@ -189,6 +189,7 @@ TEST(GripperTest, testCalibration)
    gt.sendPropertiesElectric();
 
    gr.calibrate();
+   
    baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
 
    EXPECT_TRUE(_state.calibrated == baxter_core_msgs::EndEffectorState::STATE_TRUE);

--- a/baxter_collaboration_lib/test/test_gripper.cpp
+++ b/baxter_collaboration_lib/test/test_gripper.cpp
@@ -38,10 +38,10 @@ public:
 
     void commandCb(const baxter_core_msgs::EndEffectorCommand &msg)
     {
-       // std::string _msg = &msg.command;
-       // std::string _cmd;
+        std::string _msg = msg.command;
+        std::string _cmd;
 
-
+        //ROS_INFO(msg);
         baxter_core_msgs::EndEffectorState state;
         
         state.calibrated = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
@@ -53,15 +53,21 @@ public:
         state.moving     = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
        
 
-        baxter_core_msgs::EndEffectorCommand _cmd;
-        _cmd.command = baxter_core_msgs::EndEffectorCommand::CMD_CALIBRATE;
+        //baxter_core_msgs::EndEffectorCommand _cmd;
+        _cmd = baxter_core_msgs::EndEffectorCommand::CMD_CALIBRATE;
 
-        if (msg.command == _cmd.command)
-        {
-            state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
-        } 
-
+        
+        state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        ROS_INFO("Command check and state sent sucessful");
+        
+        /*
+        
+        ROS_INFO("Command check and state set NOT successful");
+        
+        */
         state_pub.publish(state);
+        ROS_INFO("Callback response successful");
+
     }
 
     // Publishes properties of the suction cup gripper
@@ -183,16 +189,18 @@ TEST(GripperTest, testCalibration)
    std::string    limb = "left";
    bool       use_robot =  true;
 
-   Gripper gr(limb, use_robot);
-   gripperTester gt("gripper", "left");
 
+   gripperTester gt("gripper", "left");
    gt.sendPropertiesElectric();
+
+   Gripper gr(limb, use_robot);
 
    gr.calibrate();
 
    baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
 
-  // EXPECT_TRUE(_state.calibrated == baxter_core_msgs::EndEffectorState::STATE_TRUE);
+//Uncomment EXPECT_TRUE to test the calibration 
+//   EXPECT_TRUE(_state.calibrated == baxter_core_msgs::EndEffectorState::STATE_TRUE);
 
 //   gr.clearCalibration();
 //   _state = gr.getGripperState();

--- a/baxter_collaboration_lib/test/test_gripper.cpp
+++ b/baxter_collaboration_lib/test/test_gripper.cpp
@@ -1,13 +1,84 @@
 #include <gtest/gtest.h>
-
 #include "robot_interface/gripper.h"
+#include <iostream>
 
 using namespace std;
 
+// subscribes to the grippers command
+// and publishes to the grippers state
+class gripperTester
+{
+    ros::NodeHandle             nh;
+    std::string               name;
+    std::string               limb;
+    ros::Publisher        prop_pub;
+    ros::Publisher       state_pub;
+    ros::Subscriber        cmd_sub; 
+    std::mutex    mutex_properties; 
+    ros::AsyncSpinner      spinner;
+
+public:
+    explicit gripperTester(std::string _name, std::string _limb) : 
+                                name(_name), limb(_limb), spinner(1)
+    {
+        prop_pub = nh.advertise<baxter_core_msgs::EndEffectorProperties>(
+                                 "/robot/end_effector/" + limb + "_gripper/properties", 1, true);
+
+        state_pub = nh.advertise<baxter_core_msgs::EndEffectorState>(
+                                 "/robot/end_effector/" + limb + "_gripper/state", 1, true);
+   
+        cmd_sub = nh.subscribe("/robot/end_effector/" + limb + "_gripper/command",
+                                 SUBSCRIBER_BUFFER, &gripperTester::commandCb, this);
+        
+        spinner.start();
+
+        // sleep to wait for the publishers to be ready
+        ros::Duration(.5).sleep();
+    }
+
+    void commandCb(const baxter_core_msgs::EndEffectorCommand &msg)
+    {
+    
+    }
+
+    // Publishes properties of the gripper
+    void sendProperties()
+    {
+        //publish the properties then make sure they are correctly set in the tests
+        //std::lock_guard<std::mutex> lock(mutex_properties);
+        baxter_core_msgs::EndEffectorProperties prop;
+        prop.ui_type = 1u;
+        prop_pub.publish(prop);   
+    }
+
+    // Publishes the state of the gripper
+    void sendState()
+    {
+        //publish the state then make sure it's correctly set in the tests
+        baxter_core_msgs::EndEffectorState state;
+
+        state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        state.enabled    = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        state.error      = baxter_core_msgs::EndEffectorState::STATE_FALSE;
+        state.gripping   = baxter_core_msgs::EndEffectorState::STATE_FALSE;
+        state.missed     = baxter_core_msgs::EndEffectorState::STATE_FALSE;
+        state.ready      = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        state.moving     = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+
+        state_pub.publish(state);
+    }
+};
+
 TEST(GripperTest, testConstructorDefaultValues)
 {
-    string    limb = "left";
-    bool use_robot =  false;
+    std::string    limb = "left";
+    bool use_robot =  true;
+
+    gripperTester gt("gripper" , "left");
+    gt.sendProperties();
+    gt.sendState();
+    
+    //ros::Duration(2).sleep();
 
     Gripper gr(limb, use_robot);
 
@@ -20,7 +91,100 @@ TEST(GripperTest, testConstructorDefaultValues)
     EXPECT_TRUE(gr.is_gripping());
 
     EXPECT_EQ("left", gr.getGripperLimb());
+
+/*
+    baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
+
+    EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+    EXPECT_EQ(_state.enabled    , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+    EXPECT_EQ(_state.error      , baxter_core_msgs::EndEffectorState::STATE_FALSE);
+    EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_FALSE);
+    EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_FALSE);
+    EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+    EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+    */
 }
+
+// TEST(GripperTest, testDefaultStates)
+// { 
+//     std::string    limb = "left";
+//     bool use_robot =  true;
+
+//     Gripper gr(limb, use_robot);
+
+//      baxter_core_msgs::EndEffectorState _state;
+//      _state = gr.getGripperState();
+
+//     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+//     EXPECT_EQ(_state.enabled    , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+//     EXPECT_EQ(_state.error      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+//     EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+//     EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+//     EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+//     EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+    
+// } 
+
+// TEST(GripperTest, testsetGripperState)
+// { 
+//     std::string    limb = "left";
+//     bool use_robot =  true;
+
+//     Gripper gr(limb, use_robot);
+
+//     baxter_core_msgs::EndEffectorState new_state;
+//     new_state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+//     new_state.enabled    = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+//     new_state.error      = baxter_core_msgs::EndEffectorState::STATE_FALSE;
+//     new_state.gripping   = baxter_core_msgs::EndEffectorState::STATE_FALSE;
+//     new_state.missed     = baxter_core_msgs::EndEffectorState::STATE_FALSE;
+//     new_state.ready      = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+//     new_state.moving     = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+
+//     gr.setGripperState(new_state);
+//     baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
+
+//     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+//     EXPECT_EQ(_state.enabled    , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+//     EXPECT_EQ(_state.error      , baxter_core_msgs::EndEffectorState::STATE_FALSE);
+//     EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_FALSE);
+//     EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_FALSE);
+//     EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+//     EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+
+// }
+
+// TEST(GripperTest, testCalibrate)
+// { /*
+//      // causes trace/breakout ; let's use a rostest to fix this
+//     std::string    limb = "left";
+//     bool use_robot =  true;
+
+//     Gripper gr(limb, use_robot);
+
+//     gr.calibrate();
+//     baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
+    
+//     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_TRUE);
+
+//     gr.clearCalibration();
+//     _state = gr.getGripperState();
+    
+//     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_FALSE);
+//     */
+// }
+
+// TEST(GripperTest, testwithgts)
+// {    
+//     std::string    limb = "left";
+//     bool use_robot =  true;
+
+//     Gripper gr(limb, use_robot);
+//     gripperTester gt("gripper" , "left");
+
+
+
+// } 
 
 
 // Run all the tests that were declared with TEST()

--- a/baxter_collaboration_lib/test/test_gripper.cpp
+++ b/baxter_collaboration_lib/test/test_gripper.cpp
@@ -38,17 +38,48 @@ public:
 
     void commandCb(const baxter_core_msgs::EndEffectorCommand &msg)
     {
-    
+       // std::string _msg = &msg.command;
+       // std::string _cmd;
+
+
+        baxter_core_msgs::EndEffectorState state;
+        
+        state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        state.enabled    = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
+        state.error      = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
+        state.gripping   = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
+        state.missed     = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
+        state.ready      = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
+        state.moving     = baxter_core_msgs::EndEffectorState::STATE_UNKNOWN;
+       
+
+        baxter_core_msgs::EndEffectorCommand _cmd;
+        _cmd.command = baxter_core_msgs::EndEffectorCommand::CMD_CALIBRATE;
+
+        if (msg.command == _cmd.command)
+        {
+            state.calibrated = baxter_core_msgs::EndEffectorState::STATE_TRUE;
+        } 
+
+        state_pub.publish(state);
     }
 
-    // Publishes properties of the gripper
-    void sendProperties()
+    // Publishes properties of the suction cup gripper
+    void sendPropertiesSuction()
     {
         //publish the properties then make sure they are correctly set in the tests
         //std::lock_guard<std::mutex> lock(mutex_properties);
         baxter_core_msgs::EndEffectorProperties prop;
         prop.ui_type = 1u;
         prop_pub.publish(prop);   
+    }
+
+    // Publishes the properties of the electric gripper
+    void sendPropertiesElectric()
+    {
+        baxter_core_msgs::EndEffectorProperties prop;
+        prop.ui_type = 2u;
+        prop_pub.publish(prop); 
     }
 
     // Publishes the state of the gripper
@@ -69,30 +100,26 @@ public:
     }
 };
 
-TEST(GripperTest, testConstructorDefaultValues)
+TEST(GripperTest, testPropertiesAndStateSubscriber)
 {
     std::string    limb = "left";
     bool use_robot =  true;
 
     gripperTester gt("gripper" , "left");
-    gt.sendProperties();
+    gt.sendPropertiesSuction();
     gt.sendState();
-    
-    //ros::Duration(2).sleep();
 
     Gripper gr(limb, use_robot);
 
-    EXPECT_FALSE(gr.is_enabled());
-    EXPECT_FALSE(gr.is_calibrated());
-    EXPECT_FALSE(gr.is_ready_to_grip());
-    EXPECT_FALSE(gr.has_error());
-
-    EXPECT_TRUE(gr.is_sucking());
-    EXPECT_TRUE(gr.is_gripping());
-
+    EXPECT_TRUE(      gr.is_enabled());
+    EXPECT_TRUE(   gr.is_calibrated());  
+    EXPECT_TRUE(gr.is_ready_to_grip());
+    EXPECT_TRUE(      gr.is_sucking());
+    EXPECT_TRUE(     gr.is_gripping());
+    EXPECT_FALSE(      gr.has_error());
+    
     EXPECT_EQ("left", gr.getGripperLimb());
 
-/*
     baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
 
     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_TRUE);
@@ -101,29 +128,27 @@ TEST(GripperTest, testConstructorDefaultValues)
     EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_FALSE);
     EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_FALSE);
     EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_TRUE);
-    EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_TRUE);
-    */
+    EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_TRUE);    
 }
 
-// TEST(GripperTest, testDefaultStates)
-// { 
-//     std::string    limb = "left";
-//     bool use_robot =  true;
+TEST(GripperTest, testDefaultStates)
+{ 
+   std::string    limb = "left";
+   bool use_robot =  true;
 
-//     Gripper gr(limb, use_robot);
+   Gripper gr(limb, use_robot);
+   baxter_core_msgs::EndEffectorState _state;
+   _state = gr.getGripperState();
 
-//      baxter_core_msgs::EndEffectorState _state;
-//      _state = gr.getGripperState();
-
-//     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-//     EXPECT_EQ(_state.enabled    , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-//     EXPECT_EQ(_state.error      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-//     EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-//     EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-//     EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
-//     EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.enabled    , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.error      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.gripping   , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.missed     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.ready      , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
+  EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_UNKNOWN);
     
-// } 
+} 
 
 // TEST(GripperTest, testsetGripperState)
 // { 
@@ -153,26 +178,27 @@ TEST(GripperTest, testConstructorDefaultValues)
 //     EXPECT_EQ(_state.moving     , baxter_core_msgs::EndEffectorState::STATE_TRUE);
 
 // }
+TEST(GripperTest, testCalibration)
+{ 
+   std::string    limb = "left";
+   bool       use_robot =  true;
 
-// TEST(GripperTest, testCalibrate)
-// { /*
-//      // causes trace/breakout ; let's use a rostest to fix this
-//     std::string    limb = "left";
-//     bool use_robot =  true;
+   Gripper gr(limb, use_robot);
+   gripperTester gt("gripper", "left");
 
-//     Gripper gr(limb, use_robot);
+   gt.sendPropertiesElectric();
 
-//     gr.calibrate();
-//     baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
+   gr.calibrate();
+   baxter_core_msgs::EndEffectorState _state = gr.getGripperState();
+
+   EXPECT_TRUE(_state.calibrated == baxter_core_msgs::EndEffectorState::STATE_TRUE);
+
+//   gr.clearCalibration();
+//   _state = gr.getGripperState();
     
-//     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_TRUE);
-
-//     gr.clearCalibration();
-//     _state = gr.getGripperState();
+//   EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_FALSE);
     
-//     EXPECT_EQ(_state.calibrated , baxter_core_msgs::EndEffectorState::STATE_FALSE);
-//     */
-// }
+}
 
 // TEST(GripperTest, testwithgts)
 // {    

--- a/baxter_collaboration_lib/test/test_ros_thread_image.cpp
+++ b/baxter_collaboration_lib/test/test_ros_thread_image.cpp
@@ -97,14 +97,14 @@ public:
 
                 // Finds the moments
                 std::vector<cv::Moments> mu(contours.size() );
-                for(size_t i = 0; i < contours.size(); i++ )
+                for(size_t i = 0; i < contours.size(); ++i)
                 {
                     mu[i] = moments(contours[i], false );
                 }
 
                 // Finds the centroid
                 std::vector<cv::Point2f> mc(contours.size());
-                for( size_t i = 0; i < contours.size(); i++ )
+                for( size_t i = 0; i < contours.size(); ++i)
                 {
                     mc[i] = cv::Point2f( mu[i].m10/mu[i].m00 , mu[i].m01/mu[i].m00 );
                     avg_coords.x = mu[i].m10/mu[i].m00;


### PR DESCRIPTION
[Gripper]: Addition of new methods such as `open/close` that abstract `suction/position/stop` that in turn use a single publishing method `command()`. Improvements to the published messages themselves, setting of parameters, getting/setting of properties etc.

[gripper_keyboard]: created to resemble `baxter_examples/gripper_keyboard.py`. Retrieves information about gripper state and properties. Opens and closes grippers based on modified Gripper class.
